### PR TITLE
lib: fix windows build

### DIFF
--- a/lib/build.rs
+++ b/lib/build.rs
@@ -65,7 +65,11 @@ fn embed_collateral_tree() {
                     .join(&security)
                     .join("crashlog"),
             )
-            .unwrap();
+            .unwrap()
+            .iter()
+            .filter_map(|component| component.to_str())
+            .collect::<Vec<&str>>()
+            .join("/");
 
         file.write_all(
             format!(


### PR DESCRIPTION
As windows path uses backslashes as path separators, the build script has to convert the paths to use forward slashes instead.