### PR TITLE
lib: fix clippy warnings in event log extraction

### DIFF
--- a/lib/src/extract/event_log.rs
+++ b/lib/src/extract/event_log.rs
@@ -194,7 +194,7 @@ fn query_crashlogs(path: PCWSTR, query: PCWSTR, query_flags: u32) -> Result<Vec<
                 slice::from_raw_parts::<u8>(values[0].Anonymous.BinaryVal, values[0].Count as usize)
             };
 
-            match CrashLog::from_slice(&binary) {
+            match CrashLog::from_slice(binary) {
                 Ok(mut crashlog) => {
                     crashlog.metadata = metadata_from_evt_values(values[1], values[2])?;
                     crashlogs.push(crashlog)
@@ -210,7 +210,7 @@ fn query_crashlogs(path: PCWSTR, query: PCWSTR, query_flags: u32) -> Result<Vec<
 }
 
 pub(crate) fn get_crashlogs_from_event_logs(path: Option<&Path>) -> Result<Vec<CrashLog>> {
-    let evtx_path_hstring = path.map(|path| HSTRING::from(path));
+    let evtx_path_hstring = path.map(HSTRING::from);
     let evtx_path = evtx_path_hstring
         .as_ref()
         .map(|hstring| PCWSTR(hstring.as_ptr()));


### PR DESCRIPTION
This fixes the following clippy warning:

    warning: this expression creates a reference which is immediately dereferenced by the compiler

       --> src\extract\event_log.rs:197:40
        |
    197 |             match CrashLog::from_slice(&binary) {
        |                                        ^^^^^^^ help: change this to: `binary`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
        = note: `#[warn(clippy::needless_borrow)]` on by default

    warning: redundant closure
       --> src\extract\event_log.rs:213:38
        |
    213 |     let evtx_path_hstring = path.map(|path| HSTRING::from(path));
        |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `HSTRING::from`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
        = note: `#[warn(clippy::redundant_closure)]` on by default