### PR TITLE
app: fix clippy warning in unpacking logic

### DIFF
--- a/app/src/unpack.rs
+++ b/app/src/unpack.rs
@@ -14,7 +14,7 @@ fn write_file(path: &Path, slice: &[u8]) -> Result<(), Error> {
 
 #[cfg(target_os = "windows")]
 fn unpack_evtx(evtx: &Path) -> Result<(), Error> {
-    let crashlogs = CrashLog::from_windows_event_logs(Some(&evtx))
+    let crashlogs = CrashLog::from_windows_event_logs(Some(evtx))
         .inspect_err(|err| log::error!("Failed to unpack EVTX file: {err}"))?;
     let mut path = PathBuf::from(evtx);
     for (i, crashlog) in crashlogs.iter().enumerate() {


### PR DESCRIPTION
This fixes the following clippy warning:

    error: this expression creates a reference which is immediately dereferenced by the compiler
      --> src\unpack.rs:17:60
       |
    17 |     let crashlogs = CrashLog::from_windows_event_logs(Some(&evtx))
       |                                                            ^^^^^ help: change this to: `evtx`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
       = note: `-D clippy::needless-borrow` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`