### PR TITLE
Upgrade to Rust Edition 2024

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intel_crashlog_app"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [[bin]]

--- a/efi/Cargo.toml
+++ b/efi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intel_crashlog_efi"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [[bin]]

--- a/efi/src/args.rs
+++ b/efi/src/args.rs
@@ -4,11 +4,11 @@
 use alloc::fmt;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use uefi::CString16;
 use uefi::fs::PathBuf;
 use uefi::prelude::*;
 use uefi::println;
 use uefi::proto::shell_params::ShellParameters;
-use uefi::CString16;
 
 pub enum ArgsError {
     InvalidArgument(String),

--- a/efi/src/extract.rs
+++ b/efi/src/extract.rs
@@ -4,9 +4,9 @@
 use alloc::format;
 use intel_crashlog::CrashLog;
 use log::{error, warn};
+use uefi::CString16;
 use uefi::fs::{FileSystem, Path, PathBuf};
 use uefi::prelude::*;
-use uefi::CString16;
 
 fn generate_filename(crashlog: &CrashLog) -> Result<PathBuf, uefi::Error> {
     CString16::try_from(format!("{}.crashlog", crashlog.metadata).as_str())

--- a/efi/src/main.rs
+++ b/efi/src/main.rs
@@ -27,8 +27,8 @@ fn run_command(args: &Args) -> Result<(), uefi::Error> {
 
     if let Some(ref command) = args.command {
         match command {
-            Command::Extract { ref output_path } => extract::extract(output_path.as_deref()),
-            Command::Info { ref input_paths } => {
+            Command::Extract { output_path } => extract::extract(output_path.as_deref()),
+            Command::Info { input_paths } => {
                 for input_path in input_paths {
                     if let Err(err) = decode::info(input_path) {
                         println!("Cannot decode sample: {err}");
@@ -36,7 +36,7 @@ fn run_command(args: &Args) -> Result<(), uefi::Error> {
                 }
                 Ok(())
             }
-            Command::Decode { ref input_path } => decode::decode(input_path),
+            Command::Decode { input_path } => decode::decode(input_path),
         }
     } else {
         args.show_help();

--- a/efi/src/pager/update.rs
+++ b/efi/src/pager/update.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-use super::input::Command;
 use super::Pager;
+use super::input::Command;
 
 impl Pager {
     fn search(&mut self, indexes: impl IntoIterator<Item = usize>) {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intel_crashlog"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lib]

--- a/lib/src/bert.rs
+++ b/lib/src/bert.rs
@@ -6,8 +6,8 @@ pub mod berr;
 mod tests;
 
 use acpi::{
-    sdt::{SdtHeader, Signature},
     AcpiTable,
+    sdt::{SdtHeader, Signature},
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -66,7 +66,7 @@ impl Bert {
     /// If the [Berr] is not valid, None is returned.
     #[cfg(all(target_os = "uefi", feature = "extraction"))]
     pub unsafe fn berr_from_phys_mem(&self) -> Option<Berr> {
-        Berr::from_slice(self.raw_berr_from_phys_mem())
+        Berr::from_slice(unsafe { self.raw_berr_from_phys_mem() })
     }
 
     pub(super) fn to_bytes(&self) -> Vec<u8> {

--- a/lib/src/bert/berr.rs
+++ b/lib/src/bert/berr.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 use super::Bert;
+use crate::CrashLog;
 use crate::cper::fer::{FirmwareErrorRecord, FirmwareErrorRecordHeader, RECORD_ID_CRASHLOG};
 use crate::cper::{CperSection, FW_ERROR_RECORD_GUID};
-use crate::CrashLog;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]

--- a/lib/src/collateral.rs
+++ b/lib/src/collateral.rs
@@ -17,9 +17,9 @@ mod path;
 mod pvss;
 mod target_info;
 
+use crate::Error;
 use crate::header::Header;
 use crate::utils::Map;
-use crate::Error;
 #[cfg(not(feature = "std"))]
 use alloc::{string::ToString, vec::Vec};
 

--- a/lib/src/collateral/embedded.rs
+++ b/lib/src/collateral/embedded.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use super::{CollateralManager, CollateralTree, ItemPath, PVSS};
-use crate::utils::Map;
 use crate::Error;
+use crate::utils::Map;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 

--- a/lib/src/collateral/target_info.rs
+++ b/lib/src/collateral/target_info.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use super::{CollateralManager, CollateralTree, ItemPath};
-use crate::utils::Map;
 use crate::Error;
+use crate::utils::Map;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 use serde::Deserialize;

--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+use crate::Error;
 use crate::bert::{Berr, Bert};
 #[cfg(feature = "collateral_manager")]
 use crate::collateral::{CollateralManager, CollateralTree};
@@ -10,7 +11,6 @@ use crate::extract;
 use crate::metadata::Metadata;
 use crate::node::Node;
 use crate::region::Region;
-use crate::Error;
 #[cfg(not(feature = "std"))]
 use alloc::{collections::VecDeque, vec, vec::Vec};
 #[cfg(target_os = "uefi")]

--- a/lib/src/extract/efi.rs
+++ b/lib/src/extract/efi.rs
@@ -18,13 +18,15 @@ impl AcpiHandler for IdentityMapped {
         physical_address: usize,
         size: usize,
     ) -> PhysicalMapping<Self, T> {
-        PhysicalMapping::new(
-            physical_address,
-            NonNull::new(physical_address as *mut _).unwrap(),
-            size,
-            size,
-            Self,
-        )
+        unsafe {
+            PhysicalMapping::new(
+                physical_address,
+                NonNull::new(physical_address as *mut _).unwrap(),
+                size,
+                size,
+                Self,
+            )
+        }
     }
 
     fn unmap_physical_region<T>(_region: &PhysicalMapping<Self, T>) {}

--- a/lib/src/extract/event_log.rs
+++ b/lib/src/extract/event_log.rs
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-use crate::metadata;
 use crate::CrashLog;
-use std::alloc::{alloc, dealloc, Layout};
+use crate::metadata;
+use std::alloc::{Layout, alloc, dealloc};
 use std::ffi::c_void;
 use std::ops::{Deref, Drop};
 use std::path::Path;
 use std::slice;
-use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::System::EventLog::EVT_VARIANT;
 use windows::Win32::System::EventLog::*;
 use windows::Win32::System::Time::FileTimeToSystemTime;
+use windows::core::*;
 
 pub struct EvtHandle(EVT_HANDLE);
 

--- a/lib/src/ffi.rs
+++ b/lib/src/ffi.rs
@@ -21,13 +21,13 @@ use core::slice;
 use core::{ffi::c_void, ptr::NonNull};
 #[cfg(not(feature = "std"))]
 use core::{
-    ffi::{c_char, c_uchar, CStr},
+    ffi::{CStr, c_char, c_uchar},
     ptr,
 };
 #[cfg(feature = "std")]
 use std::{
     collections::VecDeque,
-    ffi::{c_char, c_uchar, CStr, CString},
+    ffi::{CStr, CString, c_char, c_uchar},
     ptr,
 };
 #[cfg(all(target_os = "uefi", feature = "extraction"))]
@@ -85,7 +85,7 @@ pub struct CrashLogNodeChildren<'a> {
 /// # Errors
 ///
 /// Returns a NULL pointer if the context cannot be initialized.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_init() -> *mut CrashLogContext {
     #[cfg(not(feature = "embedded_collateral_tree"))]
     {
@@ -120,7 +120,7 @@ pub extern "C" fn crashlog_init() -> *mut CrashLogContext {
 /// # Errors
 ///
 /// Returns a `NULL` pointer if the binary blob does not encode any valid Crash Log records.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_read_from_buffer(
     context: *mut CrashLogContext,
     data: *const u8,
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn crashlog_read_from_buffer(
 ///
 /// Returns a `NULL` pointer if the Crash Log records cannot be found.
 #[cfg(all(target_os = "uefi", feature = "extraction"))]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_read_from_system_table(
     context: *mut CrashLogContext,
     system_table: *mut c_void,
@@ -153,7 +153,7 @@ pub extern "C" fn crashlog_read_from_system_table(
 ///
 /// Returns a `NULL` pointer if the Crash Log records cannot be found.
 #[cfg(any(all(target_os = "windows", feature = "extraction"), doc))]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_read_from_windows_event_logs(
     context: *mut CrashLogContext,
 ) -> *mut CrashLogs {
@@ -172,7 +172,7 @@ pub extern "C" fn crashlog_read_from_windows_event_logs(
 ///
 /// Returns a `NULL` pointer if the Crash Log records cannot be found.
 #[cfg(any(all(target_os = "linux", feature = "extraction"), doc))]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_read_from_linux_sysfs(context: *mut CrashLogContext) -> *mut CrashLog {
     CrashLog::from_linux_sysfs()
         .map(alloc)
@@ -196,7 +196,7 @@ pub extern "C" fn crashlog_read_from_linux_sysfs(context: *mut CrashLogContext) 
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL` or if no more Crash Logs is
 /// available in the iterator.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_next(
     context: *mut CrashLogContext,
     crashlogs: *mut CrashLogs,
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn crashlog_next(
 /// # Errors
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_decode(
     context: *mut CrashLogContext,
     crashlog: *const CrashLog,
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn crashlog_decode(
 ///
 /// The `crashlog` pointer must be valid and obtained using one of the `crashlog_read_*()`
 /// functions.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_export_to_binary(
     context: *mut CrashLogContext,
     crashlog: *const CrashLog,
@@ -296,7 +296,7 @@ pub unsafe extern "C" fn crashlog_export_to_binary(
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL` or if an error happens during the
 /// generation of the JSON.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "serialize")]
 pub unsafe extern "C" fn crashlog_export_to_json(
     context: *mut CrashLogContext,
@@ -336,7 +336,7 @@ pub unsafe extern "C" fn crashlog_export_to_json(
 ///
 /// The `buffer` pointer must point to a valid writable memory region of `buffer_size` bytes.
 /// The data written to this buffer is not nul-terminated.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_read_export(
     context: *mut CrashLogContext,
     export: *mut CrashLogExport,
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn crashlog_read_export(
 /// [`crashlog_get_next_node_child`], or the [`crashlog_get_node_by_path`] functions.
 ///
 /// The `buffer` pointer must point to a writable memory region of `buffer_size` bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_get_node_name(
     context: *mut CrashLogContext,
     node: *const Node,
@@ -419,7 +419,7 @@ pub unsafe extern "C" fn crashlog_get_node_name(
 /// [`crashlog_get_next_node_child`], or the [`crashlog_get_node_by_path`] functions.
 ///
 /// The `value` pointer must point to a writable memory region of 8 bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_get_node_value(
     context: *mut CrashLogContext,
     node: *const Node,
@@ -455,7 +455,7 @@ pub unsafe extern "C" fn crashlog_get_node_value(
 /// # Errors
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_get_node_children<'a>(
     context: *mut CrashLogContext,
     node: *const Node,
@@ -488,7 +488,7 @@ pub unsafe extern "C" fn crashlog_get_node_children<'a>(
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL` or if no more node is available in
 /// the iterator.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_get_next_node_child(
     context: *mut CrashLogContext,
     children: *mut CrashLogNodeChildren,
@@ -522,7 +522,7 @@ pub unsafe extern "C" fn crashlog_get_next_node_child(
 /// # Errors
 ///
 /// Returns a `NULL` pointer if one of the arguments is `NULL` or if the node does not exist.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn crashlog_get_node_by_path(
     context: *mut CrashLogContext,
     node: *const Node,
@@ -554,7 +554,7 @@ fn free<T>(ptr: *mut T) {
 }
 
 /// Releases the memory allocated for the Crash Log.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_release(crashlog: *mut CrashLog) {
     free(crashlog)
 }
@@ -562,19 +562,19 @@ pub extern "C" fn crashlog_release(crashlog: *mut CrashLog) {
 /// Releases the memory allocated for the Crash Log register tree.
 ///
 /// The root node of the tree is expected to be passed to this function.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_release_nodes(node: *mut Node) {
     free(node)
 }
 
 /// Releases the memory allocated for the Crash Log export.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_release_export(node: *mut CrashLogExport) {
     free(node)
 }
 
 /// Releases the memory allocated for the Crash Log global context.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crashlog_deinit(ctx: *mut CrashLogContext) {
     free(ctx)
 }

--- a/lib/src/node.rs
+++ b/lib/src/node.rs
@@ -4,11 +4,11 @@
 //! A tree-like data structure containing the decoded Crash Log registers.
 
 #[cfg(feature = "std")]
-use std::collections::{btree_map, BTreeMap};
+use std::collections::{BTreeMap, btree_map};
 
 #[cfg(not(feature = "std"))]
 use alloc::{
-    collections::{btree_map, BTreeMap},
+    collections::{BTreeMap, btree_map},
     format,
     string::String,
 };

--- a/lib/src/record/core.rs
+++ b/lib/src/record/core.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 use super::Record;
+use crate::Error;
 #[cfg(feature = "collateral_manager")]
 use crate::collateral::{CollateralManager, CollateralTree};
 use crate::node::{Node, NodeType};
-use crate::Error;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 

--- a/lib/src/region.rs
+++ b/lib/src/region.rs
@@ -3,7 +3,7 @@
 
 //! Provides access to the records stored in a Crash Log region.
 
-use crate::cper::{fer, CperSection};
+use crate::cper::{CperSection, fer};
 use crate::error::Error;
 use crate::header::Header;
 use crate::record::Record;
@@ -22,7 +22,7 @@ pub struct Region {
 impl Region {
     pub(crate) fn from_cper_section(section: &CperSection) -> Option<Self> {
         match section {
-            CperSection::FirmwareErrorRecord(ref fer) => {
+            CperSection::FirmwareErrorRecord(fer) => {
                 let guid = fer.header.guid;
                 if guid == fer::RECORD_ID_CRASHLOG {
                     Region::from_slice(&fer.payload).ok()

--- a/lib/tests/collateral.rs
+++ b/lib/tests/collateral.rs
@@ -52,7 +52,8 @@ fn out_of_tree() {
         ..PVSS::default()
     };
 
-    assert!(cm
-        .get_item_with_pvss(pvss, "../../../../../../README.md")
-        .is_err());
+    assert!(
+        cm.get_item_with_pvss(pvss, "../../../../../../README.md")
+            .is_err()
+    );
 }


### PR DESCRIPTION
Update Rust edition to 2024 for all the components and fix new compiler and rustfmt warnings.