### PR TITLE
lib: improve warning message reported for empty records

### DIFF
--- a/lib/src/region.rs
+++ b/lib/src/region.rs
@@ -62,7 +62,10 @@ impl Region {
             log::debug!("Record size: 0x{record_size:04x}");
 
             if record_size == 0 {
-                log::warn!("Record has an empty size");
+                log::warn!(
+                    "{} record has an empty size. Skipping.",
+                    header.record_type().unwrap_or("UNKNOWN")
+                );
                 break;
             }
 


### PR DESCRIPTION
When a record with an empty size is decoded, the warning message reported was rather confusing as it didn't include the type of the invalid record.