### PR TITLE
lib: add support for relative paths in decode definitions

### DIFF
--- a/lib/src/node.rs
+++ b/lib/src/node.rs
@@ -206,8 +206,17 @@ impl Node {
     }
 
     pub fn create_hierarchy(&mut self, path: &str) -> &mut Node {
+        self.create_hierarchy_from_iter(path.split("."))
+    }
+
+    pub(crate) fn create_hierarchy_from_iter<S, I>(&mut self, path: I) -> &mut Node
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         let mut ptr = self;
-        for name in path.split('.') {
+        for name in path {
+            let name = name.as_ref();
             if ptr.get(name).is_none() {
                 ptr.add(Node::section(name));
             }
@@ -216,19 +225,6 @@ impl Node {
                 .expect("Node should be present in the hierarchy")
         }
         ptr
-    }
-
-    pub fn create_record_hierarchy(&mut self, path: &str) -> &mut Node {
-        match path.split_once(".") {
-            Some((record, hierarchy)) => {
-                if self.get(record).is_none() {
-                    self.add(Node::record(record));
-                }
-                let record_node = self.get_mut(record).expect("Record node should be present");
-                record_node.create_hierarchy(hierarchy)
-            }
-            None => self.create_hierarchy(path),
-        }
     }
 
     /// Returns an iterator over the node's children. The children nodes are sorted alphabetically.

--- a/lib/tests/node.rs
+++ b/lib/tests/node.rs
@@ -89,11 +89,13 @@ fn merge() {
 #[test]
 fn merge_record() {
     let mut root0 = Node::root();
-    root0.create_record_hierarchy("foo.bar.reg0");
+    root0.add(Node::record("foo"));
+    root0.create_hierarchy("foo.bar.reg0");
     root0.create_hierarchy("some.bar.reg1");
 
     let mut root1 = Node::root();
-    root1.create_record_hierarchy("foo.bar.reg1");
+    root1.add(Node::record("foo"));
+    root1.create_hierarchy("foo.bar.reg1");
 
     root0.merge(root1);
 


### PR DESCRIPTION
Some decode definitions use relative paths to reference fields. This changes refactors the CSV-based decoding flow to support these cases.

This also removes the create_record_hierarchy() function from the public API.