### PR TITLE
lib: remove unused method

### DIFF
--- a/lib/src/collateral/pvss.rs
+++ b/lib/src/collateral/pvss.rs
@@ -1,7 +1,6 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-use crate::header::Header;
 #[cfg(not(feature = "std"))]
 use alloc::{fmt, string::String};
 #[cfg(feature = "std")]
@@ -29,16 +28,6 @@ impl Default for PVSS {
             variant: "all".into(),
             stepping: "all".into(),
             security: "green".into(),
-        }
-    }
-}
-
-impl PVSS {
-    pub fn from_header(_header: &Header) -> Self {
-        PVSS {
-            product: "XYZ".into(),
-            variant: "all".into(),
-            ..PVSS::default()
         }
     }
 }


### PR DESCRIPTION
The PVSS can be derived from a record header by using the Header::pvss() method instead.