### PR TITLE
ci: fix FFI documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: mkdir _site/
       - name: Build library documentation
         working-directory: ./lib
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --all-features
       - name: Copy library documentation
         run: cp -a ./lib/target/doc/ ./_site/crates
       - name: Add redirect


### PR DESCRIPTION
As the FFI is now optional, the documentation must now be built with all the features enabled to include the FFI documentation.