### PR TITLE
lib: improve error handling for invalid target_info

### DIFF
--- a/lib/tests/collateral.rs
+++ b/lib/tests/collateral.rs
@@ -22,6 +22,7 @@ fn get_with_pvss() {
 #[test]
 fn target_info() {
     let cm = CollateralManager::file_system_tree(Path::new(COLLATERAL_TREE_PATH)).unwrap();
+    assert_eq!(cm.target_info.len(), 1);
     assert_eq!(cm.target_info.get(&0x07A).unwrap().product, "XYZ");
 }
 

--- a/lib/tests/collateral/ABC/all/all/green/crashlog/target_info.json
+++ b/lib/tests/collateral/ABC/all/all/green/crashlog/target_info.json
@@ -1,0 +1,4 @@
+{
+  "product": "ABC",
+  "product_id": []
+}


### PR DESCRIPTION
Target info might be invalid when using customized collateral trees.