### PR TITLE
lib: include `die_skt_info` in header basic decode

### DIFF
--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -607,6 +607,7 @@ impl From<&Header> for Node {
                     "record_collection_completed",
                     collection_complete as u64,
                 ));
+                node.add(die_skt_info);
 
                 for (i, completion_status) in completion_status.iter().enumerate() {
                     node.add(Node::field(

--- a/lib/tests/record.rs
+++ b/lib/tests/record.rs
@@ -151,6 +151,12 @@ fn header_type6_decode() {
         .unwrap();
 
     assert_eq!(version.kind, NodeType::Field { value: 2 });
+
+    let die_id = root
+        .get_by_path("processors.cpu0.die1.mca.hdr.die_skt_info.die_id")
+        .unwrap();
+
+    assert_eq!(die_id.kind, NodeType::Field { value: 1 });
 }
 
 #[test]


### PR DESCRIPTION
This patch includes the `die_skt_info` field in the Header Type6 when the header is being decode as part of the `basic_decode` flow.