### PR TITLE
lib: decode `die_id` from integer value

### DIFF
--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -302,7 +302,7 @@ impl Header {
     #[cfg(feature = "collateral_manager")]
     pub fn die<'a, T: CollateralTree>(&self, cm: &'a CollateralManager<T>) -> Option<&'a str> {
         let target_info = cm.target_info.get(&self.product_id())?;
-        let die_id = target_info.die_id.get(&self.die_id()?.to_string())?;
+        let die_id = target_info.die_id.get(&self.die_id()?)?;
         Some(die_id)
     }
 

--- a/lib/tests/header.rs
+++ b/lib/tests/header.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use intel_crashlog::prelude::*;
+use std::fs;
 use std::path::Path;
 
 const COLLATERAL_TREE_PATH: &str = "tests/collateral";
@@ -55,4 +56,18 @@ fn decode_header_to_node() {
         node.get_by_path("version.product_id").unwrap().kind,
         NodeType::Field { value: 0x7a }
     );
+}
+
+#[test]
+fn decode_die_id_header() {
+    let cm = CollateralManager::file_system_tree(Path::new(COLLATERAL_TREE_PATH)).unwrap();
+
+    let data = fs::read("tests/samples/dummy_mca_rev2.crashlog").unwrap();
+    let header = Header::from_slice(&data).unwrap().unwrap();
+
+    let die_id = header.die_id().unwrap();
+    assert_eq!(die_id, 1);
+
+    let die = header.die(&cm).unwrap();
+    assert_eq!(die, "io1");
 }


### PR DESCRIPTION
This patch includes an optimization when the die id name is parsed. Instead of converting an `u8` value to `String` and then getting the name of the die from the JSON, this patch includes a `Map<u8, String>`

The header library can get the die name from this new `Map<u8, String>` and removes the need to convert the original `u8` to `String`.