### PR TITLE
lib: include die name in decoded record.

### DIFF
--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -366,12 +366,28 @@ impl Header {
         }
     }
 
+    #[cfg(feature = "collateral_manager")]
+    pub(super) fn get_root_path_cm<T: CollateralTree>(
+        &self,
+        cm: &CollateralManager<T>,
+    ) -> Option<String> {
+        if let HeaderType::Type6 { socket_id, .. } = self.header_type {
+            if let Some(die) = self.die(cm) {
+                Some(format!("processors.cpu{socket_id}.{die}"))
+            } else {
+                self.get_root_path()
+            }
+        } else {
+            None
+        }
+    }
+
     pub(super) fn get_root_path(&self) -> Option<String> {
         if let HeaderType::Type6 {
             socket_id, die_id, ..
         } = self.header_type
         {
-            Some(format!("processors.cpu{}.die{}", socket_id, die_id))
+            Some(format!("processors.cpu{socket_id}.die{die_id}"))
         } else {
             None
         }

--- a/lib/src/record/decode.rs
+++ b/lib/src/record/decode.rs
@@ -52,11 +52,6 @@ impl Record {
 
     pub fn decode_with_csv(&self, layout: &[u8], offset: usize) -> Result<Node, Error> {
         let mut root = Node::root();
-        let record_root = if let Some(custom_root) = self.header.get_root_path() {
-            root.create_hierarchy(&custom_root)
-        } else {
-            &mut root
-        };
 
         let csv = str::from_utf8(layout)?;
         let mut columns = Vec::new();
@@ -97,9 +92,9 @@ impl Record {
                 current_path.clear();
                 current_path.push(top.to_owned());
 
-                if record_root.get(top).is_none() {
+                if root.get(top).is_none() {
                     // Top-level is assumed to be the record name
-                    record_root.add(Node::record(top));
+                    root.add(Node::record(top));
                 }
             }
 
@@ -111,7 +106,7 @@ impl Record {
                 }
             }
 
-            let node = record_root.create_hierarchy_from_iter(&current_path);
+            let node = root.create_hierarchy_from_iter(&current_path);
             node.description = entry.description;
             if let Some(value) = self.read_field(offset * 8 + entry.offset, entry.size) {
                 node.kind = NodeType::Field { value }
@@ -144,12 +139,20 @@ impl Record {
     ) -> Result<Node, Error> {
         let paths = self.header.decode_definitions_paths(cm)?;
 
+        let mut root = Node::root();
+        let record_root = if let Some(custom_root) = self.header.get_root_path_cm(cm) {
+            root.create_hierarchy(&custom_root)
+        } else {
+            &mut root
+        };
+
         for mut path in paths {
             path.push(decode_def);
             let Ok(layout) = cm.get_item_with_header(&self.header, path) else {
                 continue;
             };
-            return self.decode_with_csv(layout, offset);
+            record_root.merge(self.decode_with_csv(layout, offset)?);
+            return Ok(root);
         }
 
         Err(Error::MissingDecodeDefinitions(self.header.version.clone()))

--- a/lib/tests/record.rs
+++ b/lib/tests/record.rs
@@ -147,13 +147,13 @@ fn header_type6_decode() {
 
     let root = record.decode(&mut cm).unwrap();
     let version = root
-        .get_by_path("processors.cpu0.die1.mca.hdr.version.revision")
+        .get_by_path("processors.cpu0.io1.mca.hdr.version.revision")
         .unwrap();
 
     assert_eq!(version.kind, NodeType::Field { value: 2 });
 
     let die_id = root
-        .get_by_path("processors.cpu0.die1.mca.hdr.die_skt_info.die_id")
+        .get_by_path("processors.cpu0.io1.mca.hdr.die_skt_info.die_id")
         .unwrap();
 
     assert_eq!(die_id.kind, NodeType::Field { value: 1 });


### PR DESCRIPTION
This patch includes the support for the Crash Log decoder to include the die name as part of the decoded record. This die name will be part from the JSON decoded output.

At the moment only the header type6 supports die name decoding.