### PR TITLE
lib: update cbindgen to 0.28.0

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -83,9 +83,9 @@ checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "clap",
  "heck",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -87,5 +87,5 @@ version = "0.9"
 optional = true
 
 [build-dependencies.cbindgen]
-version = "0.27"
+version = "0.28"
 optional = true


### PR DESCRIPTION
Since the move to Rust Edition 2024, cbindgen 0.28.0 must be used to parse the unsafe(no_mangle) attributes.