### PR TITLE
lib: include die name decode in `basic_decode`

### DIFF
--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -155,13 +155,7 @@ impl CrashLog {
         let mut root = Node::root();
         for region in self.regions.iter() {
             for record in region.records.iter() {
-                root.merge(match record.decode(cm) {
-                    Ok(node) => node,
-                    Err(err) => {
-                        log::warn!("Cannot decode record: {err}");
-                        record.basic_decode()
-                    }
-                })
+                root.merge(record.decode(cm))
             }
         }
         root

--- a/lib/tests/crashlog.rs
+++ b/lib/tests/crashlog.rs
@@ -26,7 +26,7 @@ fn crashlog_decode() {
     let mca = root.get_by_path("mca");
     assert!(mca.is_some());
 
-    let crashlog_agent = root.get_by_path("processors.cpu0.die0.crashlog_agent");
+    let crashlog_agent = root.get_by_path("processors.cpu0.io0.crashlog_agent");
     assert!(crashlog_agent.is_some());
 }
 

--- a/lib/tests/record.rs
+++ b/lib/tests/record.rs
@@ -83,7 +83,7 @@ fn decode() {
     let header = Header::from_slice(&data).unwrap().unwrap();
     let record = Record { header, data };
 
-    let root = record.decode(&mut cm).unwrap();
+    let root = record.decode(&mut cm);
     let version = root.get_by_path("mca.hdr.version.revision").unwrap();
     assert_eq!(version.kind, NodeType::Field { value: 1 });
 }
@@ -108,7 +108,7 @@ fn decode_generic() {
     };
 
     let mut cm = CollateralManager::file_system_tree(Path::new(COLLATERAL_TREE_PATH)).unwrap();
-    let root = record.decode(&mut cm).unwrap();
+    let root = record.decode(&mut cm);
     let foo = root.get_by_path("mca.foo").unwrap();
     assert_eq!(foo.kind, NodeType::Field { value: 0x42 });
 }
@@ -134,7 +134,12 @@ fn decode_missing_decode_defs() {
 
     let mut cm = CollateralManager::file_system_tree(Path::new(COLLATERAL_TREE_PATH)).unwrap();
     let root = record.decode(&mut cm);
-    assert_matches!(root, Err(Error::MissingDecodeDefinitions(_)));
+
+    let revision = root.get_by_path("mca.hdr.version.revision").unwrap();
+    assert_eq!(revision.kind, NodeType::Field { value: 42 });
+
+    let record_size = root.get_by_path("mca.hdr.record_size.record_size").unwrap();
+    assert_eq!(record_size.kind, NodeType::Field { value: 1 });
 }
 
 #[test]
@@ -145,7 +150,7 @@ fn header_type6_decode() {
     let header = Header::from_slice(&data).unwrap().unwrap();
     let record = Record { header, data };
 
-    let root = record.decode(&mut cm).unwrap();
+    let root = record.decode(&mut cm);
     let version = root
         .get_by_path("processors.cpu0.io1.mca.hdr.version.revision")
         .unwrap();


### PR DESCRIPTION
This patch enables an alternative flow inside `decode`

When the current Crash Log record contains a Header Type 6 (which is the only header at the moment with `die_id` support) and there are no defined decode definitions, the current `basic_decode` function will still try to rename the die name when the header is decoded.