### PR TITLE
lib: rename `basic_decode` as `decode_without_cm`

### DIFF
--- a/efi/src/decode.rs
+++ b/efi/src/decode.rs
@@ -33,7 +33,7 @@ pub fn decode(input_path: &Path) -> Result<(), uefi::Error> {
 
     let nodes = match CollateralManager::embedded_tree() {
         Ok(mut cm) => crashlog.decode(&mut cm),
-        Err(_) => crashlog.basic_decode(),
+        Err(_) => crashlog.decode_without_cm(),
     };
 
     let serialized_data =

--- a/lib/README.md
+++ b/lib/README.md
@@ -90,7 +90,7 @@ let crashlog = CrashLog::from_slice(&data).unwrap();
 assert_eq!(crashlog.regions[0].records[0].header.version.revision, 1);
 
 // Decode the headers of the Crash Log records into a register tree
-let nodes = crashlog.basic_decode();
+let nodes = crashlog.decode_without_cm();
 
 // Export the register tree to JSON
 assert_eq!(

--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -139,11 +139,11 @@ impl CrashLog {
     }
 
     /// Returns the register tree representation of the Crash Log record headers.
-    pub fn basic_decode(&self) -> Node {
+    pub fn decode_without_cm(&self) -> Node {
         let mut root = Node::root();
         for region in self.regions.iter() {
             for record in region.records.iter() {
-                root.merge(record.basic_decode())
+                root.merge(record.decode_without_cm())
             }
         }
         root

--- a/lib/src/ffi.rs
+++ b/lib/src/ffi.rs
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn crashlog_decode(
     }
     #[cfg(not(feature = "embedded_collateral_tree"))]
     {
-        alloc(crashlog.basic_decode())
+        alloc(crashlog.decode_without_cm())
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -25,7 +25,7 @@
 //! assert_eq!(crashlog.regions[0].records[0].header.version.revision, 1);
 //!
 //! // Decode the headers of the Crash Log records into a register tree
-//! let nodes = crashlog.basic_decode();
+//! let nodes = crashlog.decode_without_cm();
 //!
 //! // Export the register tree to JSON
 //! assert_eq!(

--- a/lib/src/record/decode.rs
+++ b/lib/src/record/decode.rs
@@ -145,13 +145,13 @@ impl Record {
     }
 
     /// Decodes the [Record] header into a [Node] tree.
-    pub fn basic_decode(&self) -> Node {
+    pub fn decode_without_cm(&self) -> Node {
         let root_path = self.header.get_root_path();
         self.decode_header(&root_path)
     }
 
     #[cfg(feature = "collateral_manager")]
-    fn basic_decode_cm<T: CollateralTree>(&self, cm: &mut CollateralManager<T>) -> Node {
+    fn decode_header_using_cm<T: CollateralTree>(&self, cm: &mut CollateralManager<T>) -> Node {
         let root_path = self.header.get_root_path_cm(cm);
         self.decode_header(&root_path)
     }
@@ -216,7 +216,7 @@ impl Record {
             Ok(node) => node,
             Err(err) => {
                 log::warn!("Cannot decode record: {err}. Only the header fields will be decoded.");
-                self.basic_decode_cm(cm)
+                self.decode_header_using_cm(cm)
             }
         }
     }


### PR DESCRIPTION
This patch is updating the current public API of the Crash Log library.

Previously there was a function in the API for decoding called `decode` which was using the collateral manager and there was another function called `basic_decode` which was not using the collateral manager.

For clarify the concepts, this patch is renaming the `basic_decode` for `decode_without_cm`, the intention is to be more precise on the usage of that function as the term "basic" is not very clear and the usage of that function is to call the decoding library in the scenario where there is no Collateral Manager available.