### PR TITLE
app: add --version option

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -12,7 +12,7 @@ use log::LevelFilter;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(about = "Extract and decode Intel Crash Log records.")]
+#[command(version, about = "Extract and decode Intel Crash Log records.")]
 struct Cli {
     /// Path to the collateral tree. If not specified, the builtin collateral tree will be used.
     #[arg(short, long, value_name = "dir")]


### PR DESCRIPTION
Allows the CLI to display the version of the crate:

    $ iclg --version
    intel_crashlog_app 0.2.0