### PR TITLE
app: add markdown format for the info command

### DIFF
--- a/app/src/info.rs
+++ b/app/src/info.rs
@@ -55,3 +55,94 @@ pub fn compact<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Re
 
     Ok(())
 }
+
+pub fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Result<(), Error> {
+    let crashlog = CrashLog::from_slice(&std::fs::read(input)?)?;
+
+    // column widths for headers
+    let w0 = 18; // #(Region-Record)
+    let w1 = 15; // Record Type
+    let w2 = 8; // Rev.
+    let w3 = 14; // Product
+    let w4 = 10; // Size
+    let w5 = 8; // Skt
+    let w6 = 12; // Checksum
+    let w7 = 10; // Die
+
+    // update # to #(Region-Record)
+    let header = format!(
+        "| {:<w0$} | {:<w1$} | {:<w2$} | {:<w3$} | {:<w4$} | {:<w5$} | {:<w6$} | {:<w7$} |",
+        "#(Region-Record)",
+        "Record Type",
+        "Rev.",
+        "Product",
+        "Size",
+        "Skt",
+        "Checksum",
+        "Die",
+        w0 = w0,
+        w1 = w1,
+        w2 = w2,
+        w3 = w3,
+        w4 = w4,
+        w5 = w5,
+        w6 = w6,
+        w7 = w7
+    );
+    println!("{}", &header);
+    // separator line for table headers
+    println!("{}", "-".repeat(header.len()));
+
+    for (i, region) in crashlog.regions.iter().enumerate() {
+        for (j, record) in region.records.iter().enumerate() {
+            let product = if let Ok(product) = record.header.product(cm) {
+                let variant = record.header.variant(cm).unwrap_or("all");
+                format!("{product}/{variant}")
+            } else {
+                format!("{:#05x}", record.header.product_id())
+            };
+
+            let record_type = if let Ok(record_type) = record.header.record_type() {
+                record_type.into()
+            } else {
+                format!("{:#02x}", record.header.version.record_type)
+            };
+
+            let checksum = record
+                .checksum()
+                .map_or("", |check| if check { "Valid" } else { "Invalid" });
+
+            let die = if let Some(die_id) = record.header.die(cm) {
+                die_id
+            } else {
+                &record
+                    .header
+                    .die_id()
+                    .map(|die_id| die_id.to_string())
+                    .unwrap_or_default()
+            };
+
+            // populate the table
+            println!(
+                "| {:<w0$} | {:<w1$} | {:<w2$} | {:<w3$} | {:<w4$} | {:<w5$} | {:<w6$} | {:<w7$} |",
+                format!("{}-{}", i, j),
+                record_type,
+                record.header.revision(),
+                product,
+                record.header.record_size(),
+                record.header.socket_id(),
+                checksum,
+                die,
+                w0 = w0,
+                w1 = w1,
+                w2 = w2,
+                w3 = w3,
+                w4 = w4,
+                w5 = w5,
+                w6 = w6,
+                w7 = w7
+            );
+        }
+    }
+    Ok(())
+}

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, ValueEnum)]
-enum InfoFormat {
+pub(crate) enum InfoFormat {
     #[default]
     Compact,
     Markdown,
@@ -60,41 +60,8 @@ impl Command {
             }
             Command::Info {
                 input_files,
-                format: InfoFormat::Compact,
-            } => {
-                for input_file in input_files {
-                    if input_files.len() > 1 {
-                        println!("\n{}:\n", input_file.display());
-                    }
-                    if let Err(err) = info::compact(&cm, input_file) {
-                        log::error!("Error: {err}")
-                    }
-                }
-            }
-
-            Command::Info {
-                input_files,
                 format,
-            } => {
-                for input_file in input_files {
-                    if input_files.len() > 1 {
-                        println!("\n{}:\n", input_file.display());
-                    }
-                    match format {
-                        InfoFormat::Compact => {
-                            if let Err(err) = info::compact(&cm, input_file) {
-                                log::error!("Error: {err}")
-                            }
-                        }
-                        InfoFormat::Markdown => {
-                            if let Err(err) = info::markdown(&cm, input_file) {
-                                log::error!("Error: {err}")
-                            }
-                        }
-                    }
-                }
-            }
-
+            } => info::info(&cm, input_files, *format),
             Command::Unpack { input_files } => {
                 for input_file in input_files {
                     if let Err(err) = unpack::unpack(input_file) {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -32,6 +32,7 @@ struct Cli {
 enum InfoFormat {
     #[default]
     Compact,
+    Markdown,
 }
 
 #[derive(Subcommand)]
@@ -70,6 +71,30 @@ impl Command {
                     }
                 }
             }
+
+            Command::Info {
+                input_files,
+                format,
+            } => {
+                for input_file in input_files {
+                    if input_files.len() > 1 {
+                        println!("\n{}:\n", input_file.display());
+                    }
+                    match format {
+                        InfoFormat::Compact => {
+                            if let Err(err) = info::compact(&cm, input_file) {
+                                log::error!("Error: {err}")
+                            }
+                        }
+                        InfoFormat::Markdown => {
+                            if let Err(err) = info::markdown(&cm, input_file) {
+                                log::error!("Error: {err}")
+                            }
+                        }
+                    }
+                }
+            }
+
             Command::Unpack { input_files } => {
                 for input_file in input_files {
                     if let Err(err) = unpack::unpack(input_file) {


### PR DESCRIPTION
This changeset adds a markdown format for the info command. Right now, two formats are supported - 'compact' and 'markdown'.

Usage:
    $ iclg info --format markdown sample.crashlog