### PR TITLE
lib: fix clippy warning

### DIFF
--- a/lib/src/node.rs
+++ b/lib/src/node.rs
@@ -243,7 +243,7 @@ impl Node {
     /// assert_eq!(children.next(), Some(&Node::section("foo")));
     /// assert_eq!(children.next(), None);
     /// ```
-    pub fn children(&self) -> NodeChildren {
+    pub fn children(&self) -> NodeChildren<'_> {
         NodeChildren {
             iter: self.children.values(),
         }


### PR DESCRIPTION
Fix the following clippy warning:

    warning: lifetime flowing from input to output with different syntax can be confusing