### PR TITLE
lib: add support for extraction from intel_pmt sysfs

### DIFF
--- a/app/src/extract.rs
+++ b/app/src/extract.rs
@@ -15,7 +15,16 @@ pub fn extract(output_path: Option<&Path>) {
     }
     #[cfg(target_os = "linux")]
     {
-        result = CrashLog::from_linux_sysfs().map(|crashlog| Vec::from([crashlog]));
+        let crashlogs: Vec<CrashLog> = [CrashLog::from_acpi_sysfs(), CrashLog::from_pmt_sysfs()]
+            .into_iter()
+            .filter_map(|crashlog| crashlog.ok())
+            .collect();
+
+        result = if crashlogs.is_empty() {
+            Err(Error::NoCrashLogFound)
+        } else {
+            Ok(crashlogs)
+        };
     }
 
     match result {

--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -6,19 +6,13 @@ use crate::bert::{Berr, Bert};
 #[cfg(feature = "collateral_manager")]
 use crate::collateral::{CollateralManager, CollateralTree};
 use crate::cper::Cper;
-#[cfg(feature = "extraction")]
-use crate::extract;
 use crate::metadata::Metadata;
 use crate::node::Node;
 use crate::region::Region;
 #[cfg(not(feature = "std"))]
 use alloc::{collections::VecDeque, vec, vec::Vec};
-#[cfg(target_os = "uefi")]
-use core::ptr::NonNull;
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
-#[cfg(target_os = "uefi")]
-use uefi_raw::table::system::SystemTable;
 
 use crate::header::HeaderType;
 use crate::header::record_types;
@@ -33,7 +27,7 @@ pub struct CrashLog {
 }
 
 impl CrashLog {
-    fn from_regions(regions: Vec<Region>) -> Result<Self, Error> {
+    pub(crate) fn from_regions(regions: Vec<Region>) -> Result<Self, Error> {
         let mut queue = VecDeque::from(regions);
         let mut regions = Vec::new();
 
@@ -85,25 +79,15 @@ impl CrashLog {
         CrashLog::from_regions(regions)
     }
 
-    #[cfg(all(target_os = "uefi", feature = "extraction"))]
-    /// Reads the Crash Log records from the EFI System Table.
-    pub fn from_system_table(system_table: Option<NonNull<SystemTable>>) -> Result<Self, Error> {
-        extract::efi::get_crashlog_from_system_table(system_table)
-    }
-
     #[cfg(any(all(target_os = "windows", feature = "extraction"), doc))]
-    /// Searches for any Intel Crash Log logged in the Windows event log
+    /// Searches for any Intel Crash Log logged in the Windows event logs.
+    ///
+    /// The Windows event logs typically captures the records reported through ACPI.
     pub fn from_windows_event_logs(path: Option<&std::path::Path>) -> Result<Vec<Self>, Error> {
-        extract::event_log::get_crashlogs_from_event_logs(path).map_err(|err| {
+        Self::from_event_logs(path).map_err(|err| {
             log::error!("Error while accessing windows event logs: {err}");
             Error::InternalError
         })
-    }
-
-    #[cfg(any(all(target_os = "linux", feature = "extraction"), doc))]
-    /// Reads the Crash Log reported through ACPI from the linux sysfs
-    pub fn from_linux_sysfs() -> Result<Self, Error> {
-        extract::sysfs::read_berr_from_sysfs().and_then(CrashLog::from_berr)
     }
 
     /// Extracts the Crash Log records from [Cper] record.

--- a/lib/src/extract/sysfs.rs
+++ b/lib/src/extract/sysfs.rs
@@ -1,16 +1,76 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+use crate::CrashLog;
 use crate::bert::Berr;
 use crate::error::Error;
+use crate::region::Region;
 
 const BERR_PATH: &str = "/sys/firmware/acpi/tables/data/BERT";
+const PMT_PATH: &str = "/sys/class/intel_pmt";
 
-pub(crate) fn read_berr_from_sysfs() -> Result<Berr, Error> {
-    std::fs::read(BERR_PATH)
-        .map_err(|err| match err.kind() {
-            std::io::ErrorKind::NotFound => Error::NoCrashLogFound,
-            _ => Error::from(err),
-        })
-        .and_then(|berr| Berr::from_slice(&berr).ok_or(Error::InvalidBootErrorRecordRegion))
+impl CrashLog {
+    /// Reads the Crash Log reported through ACPI from the linux sysfs
+    pub fn from_acpi_sysfs() -> Result<Self, Error> {
+        let berr = std::fs::read(BERR_PATH)
+            .map_err(|err| {
+                log::warn!("Cannot read {BERR_PATH}: {err}");
+                match err.kind() {
+                    std::io::ErrorKind::NotFound => Error::NoCrashLogFound,
+                    _ => Error::from(err),
+                }
+            })
+            .and_then(|berr| {
+                log::info!("Found ACPI boot error record in sysfs");
+                Berr::from_slice(&berr).ok_or(Error::InvalidBootErrorRecordRegion)
+            })?;
+
+        Self::from_berr(berr)
+    }
+
+    /// Reads the Crash Log reported through Intel PMT from the linux sysfs
+    pub fn from_pmt_sysfs() -> Result<Self, Error> {
+        let regions: Vec<Region> = std::fs::read_dir(PMT_PATH)
+            .map_err(|err| {
+                log::warn!("Cannot read {PMT_PATH}: {err}");
+                match err.kind() {
+                    std::io::ErrorKind::NotFound => Error::NoCrashLogFound,
+                    _ => Error::from(err),
+                }
+            })?
+            .filter_map(|entry| {
+                entry
+                    .inspect_err(|err| log::error!("Cannot access directory entry: {err}"))
+                    .ok()
+            })
+            .filter(|entry| {
+                let is_dir = entry
+                    .file_type()
+                    .map(|file_type| file_type.is_dir())
+                    .unwrap_or(false);
+                let is_crashlog_dir = entry
+                    .file_name()
+                    .to_str()
+                    .map(|name| name.starts_with("crashlog"))
+                    .unwrap_or(false);
+
+                is_dir && is_crashlog_dir
+            })
+            .filter_map(|entry| {
+                let mut path = entry.path();
+
+                log::info!("Found Crash Log entry in PMT sysfs: {}", path.display());
+                path.push("crashlog");
+
+                std::fs::read(&path)
+                    .map_err(Error::IOError)
+                    .and_then(|region| Region::from_slice(&region))
+                    .inspect(|_| log::info!("Extracted valid record from {}", path.display()))
+                    .inspect_err(|err| log::error!("{}: {err}", path.display()))
+                    .ok()
+            })
+            .collect();
+
+        Self::from_regions(regions)
+    }
 }

--- a/lib/src/ffi.rs
+++ b/lib/src/ffi.rs
@@ -169,15 +169,28 @@ pub extern "C" fn crashlog_read_from_windows_event_logs(
         .unwrap_or(ptr::null_mut())
 }
 
-/// Reads the Crash Log reported through ACPI from the linux sysfs.
+/// Reads the Crash Log reported through ACPI from the linux sysfs
 ///
 /// # Errors
 ///
-/// Returns a `NULL` pointer if the Crash Log records cannot be found.
+/// Returns a `NULL` pointer if the Crash Log record cannot be found.
 #[cfg(any(all(target_os = "linux", feature = "extraction"), doc))]
 #[unsafe(no_mangle)]
-pub extern "C" fn crashlog_read_from_linux_sysfs(context: *mut CrashLogContext) -> *mut CrashLog {
-    CrashLog::from_linux_sysfs()
+pub extern "C" fn crashlog_read_from_acpi_sysfs(context: *mut CrashLogContext) -> *mut CrashLog {
+    CrashLog::from_acpi_sysfs()
+        .map(alloc)
+        .unwrap_or(ptr::null_mut())
+}
+
+/// Reads the Crash Log reported through Intel PMT from the linux sysfs
+///
+/// # Errors
+///
+/// Returns a `NULL` pointer if the Crash Log record cannot be found.
+#[cfg(any(all(target_os = "linux", feature = "extraction"), doc))]
+#[unsafe(no_mangle)]
+pub extern "C" fn crashlog_read_from_pmt_sysfs(context: *mut CrashLogContext) -> *mut CrashLog {
+    CrashLog::from_pmt_sysfs()
         .map(alloc)
         .unwrap_or(ptr::null_mut())
 }


### PR DESCRIPTION
The Crash Log regions that are exposed by Intel PMT are accessible through the linux sysfs.

The linux extraction function implemented in the library is being updated to look for any valid records that can be found in the ACPI tables and PMT structures.