### PR TITLE
lib: handle empty regions

### DIFF
--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -58,7 +58,7 @@ impl CrashLog {
                         };
                         queue.push_front(region)
                     }
-                    Err(err) => log::error!("Invalid region in Box record: {err}"),
+                    Err(err) => log::warn!("Invalid region in Box record: {err}"),
                 }
             }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -25,6 +25,7 @@ pub enum Error {
     MissingDecodeDefinitions(Version),
     InvalidBootErrorRecordRegion,
     InvalidHeader,
+    EmptyRegion,
     InvalidHeaderType(u16),
     InvalidRecordType(u8),
     InvalidProductID(u32),
@@ -57,6 +58,7 @@ impl fmt::Display for Error {
             }
             Error::InvalidBootErrorRecordRegion => write!(f, "Invalid Boot Error Record region"),
             Error::InvalidHeader => write!(f, "Invalid Crash Log Header"),
+            Error::EmptyRegion => write!(f, "The Crash Log Region is not populated"),
             Error::InvalidHeaderType(ht) => write!(f, "Invalid Crash Log Header Type: {ht}"),
             Error::InvalidRecordType(rt) => write!(f, "Unknown Crash Log Record Type: {rt:#x}"),
             Error::InvalidProductID(pid) => write!(f, "Unknown Crash Log Product ID: {pid:#x}"),

--- a/lib/src/region.rs
+++ b/lib/src/region.rs
@@ -94,6 +94,10 @@ impl Region {
             cursor += record_size;
         }
 
+        if region.records.is_empty() {
+            return Err(Error::EmptyRegion);
+        }
+
         Ok(region)
     }
 

--- a/lib/tests/region.rs
+++ b/lib/tests/region.rs
@@ -15,3 +15,9 @@ fn from_slice() {
 
     assert!(region.is_ok());
 }
+
+#[test]
+fn empty() {
+    let region = Region::from_slice(&[]);
+    assert!(region.is_err());
+}


### PR DESCRIPTION
The box record payload does not always contain data. Checking if the region is empty during its construction prevents the invalid box payload to appear in the region list stored in the Crash Log struct.

This also prevents the unpack command to report empty regions and the decode function to consider empty files as valid.

    $ touch empty.crashlog
    $ iclg decode empty.crashlog
    Fatal Error: The Crash Log Region is not populated