### PR TITLE
doc: update command line to build documentation

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -63,7 +63,7 @@
 Generate the HTML documentation with:
 
 ```
-$ cargo doc
+$ cargo doc --all-features
 ```
 
 The documentation will be available under the `target/doc/intel_crashlog/`


### PR DESCRIPTION
All the crate features must be enabled when building the documentation.