### PR TITLE
lib: include decode support for legacy header Type0 Box records

### DIFF
--- a/lib/src/record/decode.rs
+++ b/lib/src/record/decode.rs
@@ -230,12 +230,15 @@ impl Record {
     /// collateral tree.
     #[cfg(feature = "collateral_manager")]
     pub fn decode<T: CollateralTree>(&self, cm: &mut CollateralManager<T>) -> Node {
-        let record =
-            if let record_types::PCORE | record_types::ECORE = self.header.version.record_type {
-                self.decode_as_core_record(cm)
-            } else {
-                self.decode_with_decode_def(cm, "layout.csv", 0)
-            };
+        let is_core = ((self.header.version.record_type == record_types::PCORE)
+            || (self.header.version.record_type == record_types::ECORE))
+            && !self.header.version.into_errata().type0_legacy_server_box;
+
+        let record = if is_core {
+            self.decode_as_core_record(cm)
+        } else {
+            self.decode_with_decode_def(cm, "layout.csv", 0)
+        };
 
         let record_node = match record {
             Ok(node) => node,

--- a/lib/tests/crashlog.rs
+++ b/lib/tests/crashlog.rs
@@ -86,4 +86,10 @@ fn legacy_type0_box() {
         .unwrap();
 
     assert_eq!(product_id.kind, NodeType::Field { value: 0x79 });
+
+    let box_revision = root
+        .get_by_path("processors.cpu1.die10.pcore.hdr.version.revision")
+        .unwrap();
+
+    assert_eq!(box_revision.kind, NodeType::Field { value: 0x81 });
 }


### PR DESCRIPTION
This patch includes support for decoding Crash Log records that have a legacy `Type0` Header with a type of `PCORE`, which behaves like a `BOX` record.