### PR TITLE
lib: export Crash Log as UEFI CPER instead of ACPI BERT

### DIFF
--- a/lib/src/bert/tests.rs
+++ b/lib/src/bert/tests.rs
@@ -24,7 +24,7 @@ fn crashlog_bert() {
 
     assert_eq!(crashlog.regions.len(), 2);
 
-    let bytes = crashlog.to_bytes();
+    let bytes = crashlog.to_bert();
     let berr = Berr::from_bert_file(&bytes);
     assert!(berr.is_some());
     let berr = berr.unwrap();

--- a/lib/src/cper.rs
+++ b/lib/src/cper.rs
@@ -3,166 +3,116 @@
 
 #![allow(dead_code)]
 
-pub mod fer;
+pub mod descr;
+pub mod header;
+pub mod revision;
+pub mod section;
 #[cfg(test)]
 mod tests;
+mod utils;
 
+use crate::CrashLog;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use fer::FirmwareErrorRecord;
-use uguid::Guid;
+use descr::{CperSectionDescriptor, SECTION_DESCRIPTOR_SIZE};
+use header::{CperHeader, RECORD_HEADER_SIZE};
+pub use section::{CperSection, CperSectionBody};
 
-pub const FW_ERROR_RECORD_GUID: Guid = uguid::guid!("81212a96-09ed-4996-9471-8d729c8e69ed");
-const RECORD_HEADER_SIZE: usize = 128;
-const SECTION_DESCRIPTOR_SIZE: usize = 72;
-
-pub enum CperSection {
-    FirmwareErrorRecord(FirmwareErrorRecord),
-    Unknown(Vec<u8>),
-}
-
-impl CperSection {
-    pub(super) fn from_slice(guid: uguid::Guid, s: &[u8]) -> Option<CperSection> {
-        Some(match guid {
-            FW_ERROR_RECORD_GUID => {
-                CperSection::FirmwareErrorRecord(fer::FirmwareErrorRecord::from_slice(s)?)
-            }
-            _ => CperSection::Unknown(Vec::from(s)),
-        })
-    }
-
-    pub(super) fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            CperSection::FirmwareErrorRecord(fer) => fer.to_bytes(),
-            CperSection::Unknown(data) => data.clone(),
-        }
-    }
-}
-
-pub struct Revision {
-    pub minor: u8,
-    pub major: u8,
-}
-
-pub struct CperSectionDescriptor {
-    pub section_offset: u32,
-    pub section_length: u32,
-    pub revision: Revision,
-    pub validation_bits: u8,
-    pub reserved: u8,
-    pub flags: u32,
-    pub section_type: Guid,
-    pub fru_id: Guid,
-    pub section_severity: u32,
-    pub fru_text: [u8; 20],
-}
-
-impl CperSectionDescriptor {
-    fn from_slice(s: &[u8]) -> Option<Self> {
-        Some(CperSectionDescriptor {
-            section_offset: u32::from_le_bytes(s.get(0..4)?.try_into().ok()?),
-            section_length: u32::from_le_bytes(s.get(4..8)?.try_into().ok()?),
-            revision: Revision {
-                minor: *s.get(8)?,
-                major: *s.get(9)?,
-            },
-            validation_bits: *s.get(10)?,
-            reserved: *s.get(11)?,
-            flags: u32::from_le_bytes(s.get(12..16)?.try_into().ok()?),
-            section_type: Guid::from_bytes(s.get(16..32)?.try_into().ok()?),
-            fru_id: Guid::from_bytes(s.get(32..48)?.try_into().ok()?),
-            section_severity: u32::from_le_bytes(s.get(48..52)?.try_into().ok()?),
-            fru_text: s.get(52..72)?.try_into().ok()?,
-        })
-    }
-}
-
-pub struct Section {
-    pub descriptor: CperSectionDescriptor,
-    pub section: CperSection,
-}
-
-pub struct CperHeader {
-    pub signature_start: u32,
-    pub revision: Revision,
-    pub signature_end: u32,
-    pub section_count: u16,
-    pub error_severity: u32,
-    pub validation_bits: u32,
-    pub record_length: u32,
-    pub timestamp: u64,
-    pub platform_id: Guid,
-    pub partition_id: Guid,
-    pub creator_id: Guid,
-    pub notification_type: Guid,
-    pub record_id: u64,
-    pub flags: u32,
-    pub persistence_information: u64,
-    pub reserved: [u8; 12],
-}
-
-impl CperHeader {
-    fn from_slice(s: &[u8]) -> Option<Self> {
-        if s.starts_with(b"CPER") {
-            Some(CperHeader {
-                signature_start: u32::from_le_bytes(s.get(0..4)?.try_into().ok()?),
-                revision: Revision {
-                    minor: *s.get(4)?,
-                    major: *s.get(5)?,
-                },
-                signature_end: u32::from_le_bytes(s.get(6..10)?.try_into().ok()?),
-                section_count: u16::from_le_bytes(s.get(10..12)?.try_into().ok()?),
-                error_severity: u32::from_le_bytes(s.get(12..16)?.try_into().ok()?),
-                validation_bits: u32::from_le_bytes(s.get(16..20)?.try_into().ok()?),
-                record_length: u32::from_le_bytes(s.get(20..24)?.try_into().ok()?),
-                timestamp: u64::from_le_bytes(s.get(24..32)?.try_into().ok()?),
-                platform_id: Guid::from_bytes(s.get(32..48)?.try_into().ok()?),
-                partition_id: Guid::from_bytes(s.get(48..64)?.try_into().ok()?),
-                creator_id: Guid::from_bytes(s.get(64..80)?.try_into().ok()?),
-                notification_type: Guid::from_bytes(s.get(80..96)?.try_into().ok()?),
-                record_id: u64::from_le_bytes(s.get(96..104)?.try_into().ok()?),
-                flags: u32::from_le_bytes(s.get(104..108)?.try_into().ok()?),
-                persistence_information: u64::from_le_bytes(s.get(108..116)?.try_into().ok()?),
-                reserved: s.get(116..128)?.try_into().ok()?,
-            })
-        } else {
-            None
-        }
-    }
-}
-
+/// UEFI Common Platform Error Record (N)
+#[derive(Default)]
 pub struct Cper {
     /// CPER Record Header
-    pub record_header: CperHeader,
+    record_header: CperHeader,
     /// CPER Sections
-    pub sections: Vec<Section>,
+    pub sections: Vec<CperSection>,
 }
 
 impl Cper {
-    /// Decodes the CPER stored in a byte slice
+    /// Parses the CPER stored in a byte slice.
     pub fn from_slice(slice: &[u8]) -> Option<Self> {
         let record_header = CperHeader::from_slice(slice.get(0..RECORD_HEADER_SIZE)?)?;
 
         let sections = (0..record_header.section_count)
-            .map(|i| {
+            .filter_map(|i| {
                 let index = RECORD_HEADER_SIZE + (i as usize * SECTION_DESCRIPTOR_SIZE);
                 let descriptor = CperSectionDescriptor::from_slice(slice.get(index..)?)?;
                 let offset = descriptor.section_offset as usize;
                 let end_offset = offset + descriptor.section_length as usize;
-                let section = CperSection::from_slice(
+                let body = CperSectionBody::from_slice(
                     descriptor.section_type,
                     slice.get(offset..end_offset)?,
                 )?;
-                Some(Section {
-                    descriptor,
-                    section,
-                })
+                Some(CperSection { descriptor, body })
             })
-            .collect::<Option<Vec<Section>>>()?;
+            .collect::<Vec<CperSection>>();
 
-        Some(Cper {
+        let mut cper = Cper {
             record_header,
             sections,
-        })
+        };
+        cper.normalize();
+        Some(cper)
+    }
+
+    /// Create a CPER Section from a Crash Log.
+    pub fn from_raw_crashlog(crashlog: &CrashLog) -> Self {
+        let mut cper = Cper::default();
+
+        cper.record_header.notification_type = header::notification_types::BOOT;
+        cper.record_header.error_severity = header::ErrorSeverity::Fatal;
+
+        cper.record_header.timestamp = crashlog
+            .metadata
+            .time
+            .as_ref()
+            .map(header::Timestamp::from_crashlog_metadata);
+
+        for region in crashlog.regions.iter() {
+            let mut section = CperSection::from_crashlog_region(region);
+            section.descriptor.section_severity = descr::SectionSeverity::Fatal;
+            cper.append_section(section);
+        }
+
+        cper
+    }
+
+    /// Appends a section to the CPER record and updates the header fields to reflect the actual
+    /// binary layout of the CPER.
+    pub fn append_section(&mut self, section: CperSection) {
+        self.sections.push(section);
+        self.normalize();
+    }
+
+    /// Updates the fields of the structures to reflect the actual binary layout of the CPER.
+    fn normalize(&mut self) {
+        self.record_header.section_count = self.sections.len() as u16;
+
+        let mut cursor = RECORD_HEADER_SIZE + SECTION_DESCRIPTOR_SIZE * self.sections.len();
+
+        for section in self.sections.iter_mut() {
+            section.descriptor.section_offset = cursor as u32;
+            section.descriptor.normalize();
+            cursor += section.descriptor.section_length as usize;
+        }
+
+        self.record_header.record_length = cursor as u32;
+        self.record_header.normalize();
+    }
+
+    /// Serializes the CPER
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.append(&mut self.record_header.to_bytes());
+
+        for section in self.sections.iter() {
+            bytes.append(&mut section.descriptor.to_bytes())
+        }
+
+        for section in self.sections.iter() {
+            bytes.append(&mut section.body_bytes())
+        }
+
+        bytes
     }
 }

--- a/lib/src/cper/descr.rs
+++ b/lib/src/cper/descr.rs
@@ -1,0 +1,137 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::revision::Revision;
+use uguid::Guid;
+
+pub const SECTION_DESCRIPTOR_SIZE: usize = 72;
+
+mod validation {
+    pub const FRU_ID: u8 = 1;
+    pub const FRU_STRING: u8 = 2;
+}
+
+mod flags {
+    pub const PRIMARY: u32 = 1 << 0;
+    pub const CONTAINMENT_WARNING: u32 = 1 << 1;
+    pub const RESET: u32 = 1 << 2;
+    pub const ERROR_THRESHOLD_EXCEEDED: u32 = 1 << 3;
+    pub const RESOURCE_NOT_ACCESSIBLE: u32 = 1 << 4;
+    pub const LATENT_ERROR: u32 = 1 << 5;
+    pub const PROPAGATED: u32 = 1 << 6;
+    pub const OVERFLOW: u32 = 1 << 7;
+}
+
+#[derive(Clone, Copy, Default)]
+#[repr(u32)]
+pub enum SectionSeverity {
+    Recoverable = 0,
+    Fatal = 1,
+    Corrected = 2,
+    #[default]
+    Informational = 3,
+}
+
+impl From<u32> for SectionSeverity {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => SectionSeverity::Recoverable,
+            1 => SectionSeverity::Fatal,
+            2 => SectionSeverity::Corrected,
+            _ => SectionSeverity::Informational,
+        }
+    }
+}
+
+/// UEFI 2.10 N.2.2 Section Descriptor.
+#[derive(Clone)]
+pub struct CperSectionDescriptor {
+    pub section_offset: u32,
+    pub section_length: u32,
+    pub revision: Revision,
+    pub validation_bits: u8,
+    pub flags: u32,
+    pub section_type: Guid,
+    pub fru_id: Option<Guid>,
+    pub section_severity: SectionSeverity,
+    pub fru_text: Option<[u8; 20]>,
+}
+
+impl Default for CperSectionDescriptor {
+    fn default() -> Self {
+        Self {
+            section_offset: 0,
+            section_length: 0,
+            revision: Revision::new(1, 0),
+            validation_bits: 0,
+            flags: 0,
+            section_type: Guid::default(),
+            fru_id: None,
+            section_severity: SectionSeverity::default(),
+            fru_text: None,
+        }
+    }
+}
+
+impl CperSectionDescriptor {
+    /// Parses the CPER Section Descriptor stored in a byte slice.
+    pub fn from_slice(s: &[u8]) -> Option<Self> {
+        let revision = Revision::from_slice(s.get(8..10)?)?;
+        if revision.major != 1 {
+            log::warn!("Unsupported CPER Section Descriptor revision: {revision}");
+        }
+
+        let validation_bits = *s.get(10)?;
+
+        Some(CperSectionDescriptor {
+            section_offset: u32::from_le_bytes(s.get(0..4)?.try_into().ok()?),
+            section_length: u32::from_le_bytes(s.get(4..8)?.try_into().ok()?),
+            revision,
+            validation_bits,
+            flags: u32::from_le_bytes(s.get(12..16)?.try_into().ok()?),
+            section_type: Guid::from_bytes(s.get(16..32)?.try_into().ok()?),
+            fru_id: if validation_bits & validation::FRU_ID != 0 {
+                Some(Guid::from_bytes(s.get(32..48)?.try_into().ok()?))
+            } else {
+                None
+            },
+            section_severity: u32::from_le_bytes(s.get(48..52)?.try_into().ok()?).into(),
+            fru_text: if validation_bits & validation::FRU_STRING != 0 {
+                Some(s.get(52..72)?.try_into().ok()?)
+            } else {
+                None
+            },
+        })
+    }
+
+    /// Updates the fields of the structure to reflect the actual binary layout.
+    pub fn normalize(&mut self) {
+        self.validation_bits = 0;
+        if self.fru_id.is_some() {
+            self.validation_bits |= validation::FRU_ID;
+        }
+        if self.fru_text.is_some() {
+            self.validation_bits |= validation::FRU_STRING;
+        }
+    }
+
+    /// Serializes the CPER Section Descriptor.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.extend_from_slice(&self.section_offset.to_le_bytes());
+        bytes.extend_from_slice(&self.section_length.to_le_bytes());
+        bytes.append(&mut self.revision.to_bytes());
+
+        bytes.push(self.validation_bits);
+        bytes.push(0);
+        bytes.extend_from_slice(&self.flags.to_le_bytes());
+        bytes.extend_from_slice(&self.section_type.to_bytes());
+        bytes.extend_from_slice(&self.fru_id.unwrap_or_default().to_bytes());
+        bytes.extend_from_slice(&(self.section_severity as u32).to_le_bytes());
+        bytes.extend_from_slice(&self.fru_text.unwrap_or_default());
+
+        debug_assert_eq!(bytes.len(), SECTION_DESCRIPTOR_SIZE);
+        bytes
+    }
+}

--- a/lib/src/cper/header.rs
+++ b/lib/src/cper/header.rs
@@ -1,0 +1,223 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
+use super::revision::Revision;
+use super::utils;
+use crate::metadata;
+use uguid::Guid;
+
+pub const RECORD_HEADER_SIZE: usize = 128;
+const LCF_GUID: Guid = uguid::guid!("eba67344-b876-4237-b80d-27e1297fa2ff");
+
+pub mod validation {
+    pub const PLATFORM_ID: u32 = 1;
+    pub const TIMESTAMP: u32 = 2;
+    pub const PARTITION_ID: u32 = 4;
+}
+
+pub mod flags {
+    pub const RECOVERED: u32 = 1 << 0;
+    pub const PREVERR: u32 = 1 << 1;
+    pub const SIMULATED: u32 = 1 << 2;
+}
+
+pub mod notification_types {
+    use uguid::Guid;
+    pub const BOOT: Guid = uguid::guid!("3d61a466-ab40-409a-a698-f362d464b38f");
+}
+
+#[derive(Clone, Copy, Default)]
+#[repr(u32)]
+pub enum ErrorSeverity {
+    Recoverable = 0,
+    Fatal = 1,
+    Corrected = 2,
+    #[default]
+    Informational = 3,
+}
+
+impl From<u32> for ErrorSeverity {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => ErrorSeverity::Recoverable,
+            1 => ErrorSeverity::Fatal,
+            2 => ErrorSeverity::Corrected,
+            _ => ErrorSeverity::Informational,
+        }
+    }
+}
+
+/// Timestamp field used in the CPER Header
+#[derive(Clone, Default)]
+pub struct Timestamp {
+    pub seconds: u8,
+    pub minutes: u8,
+    pub hours: u8,
+    pub precise: bool,
+    pub day: u8,
+    pub month: u8,
+    pub year: u8,
+    pub century: u8,
+}
+
+impl Timestamp {
+    pub fn from_crashlog_metadata(time: &metadata::Time) -> Self {
+        Self {
+            century: utils::bin_to_bcd((time.year / 100) as u8),
+            year: utils::bin_to_bcd((time.year % 100) as u8),
+            month: utils::bin_to_bcd(time.month),
+            day: utils::bin_to_bcd(time.day),
+            hours: utils::bin_to_bcd(time.hour),
+            minutes: utils::bin_to_bcd(time.minute),
+            ..Self::default()
+        }
+    }
+
+    pub fn from_slice(s: &[u8]) -> Option<Self> {
+        Some(Self {
+            seconds: *s.first()?,
+            minutes: *s.get(1)?,
+            hours: *s.get(2)?,
+            precise: *s.get(3)? & 1 != 0,
+            day: *s.get(4)?,
+            month: *s.get(5)?,
+            year: *s.get(6)?,
+            century: *s.get(7)?,
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        vec![
+            self.seconds,
+            self.minutes,
+            self.hours,
+            self.precise as u8,
+            self.day,
+            self.month,
+            self.year,
+            self.century,
+        ]
+    }
+}
+
+/// UEFI 2.10 N.2.1 Record Header.
+#[derive(Clone)]
+pub struct CperHeader {
+    pub revision: Revision,
+    pub section_count: u16,
+    pub error_severity: ErrorSeverity,
+    pub validation_bits: u32,
+    pub record_length: u32,
+    pub timestamp: Option<Timestamp>,
+    pub platform_id: Option<Guid>,
+    pub partition_id: Option<Guid>,
+    pub creator_id: Guid,
+    pub notification_type: Guid,
+    pub record_id: u64,
+    pub flags: u32,
+    pub persistence_information: u64,
+}
+
+impl Default for CperHeader {
+    fn default() -> Self {
+        Self {
+            revision: Revision::new(1, 1),
+            section_count: 0,
+            error_severity: ErrorSeverity::default(),
+            validation_bits: 0,
+            record_length: RECORD_HEADER_SIZE as u32,
+            timestamp: None,
+            platform_id: None,
+            partition_id: None,
+            creator_id: LCF_GUID,
+            notification_type: Guid::default(),
+            record_id: 0,
+            flags: 0,
+            persistence_information: 0,
+        }
+    }
+}
+
+impl CperHeader {
+    /// Parses the CPER header stored in a byte slice.
+    pub fn from_slice(s: &[u8]) -> Option<Self> {
+        let signature_end = u32::from_le_bytes(s.get(6..10)?.try_into().ok()?);
+        if !s.starts_with(b"CPER") || signature_end != 0xFFFFFFFF {
+            return None;
+        }
+        let revision = Revision::from_slice(s.get(4..6)?)?;
+        if revision.major != 1 {
+            log::warn!("Unsupported CPER Record Header revision: {revision}.");
+        }
+
+        let validation_bits = u32::from_le_bytes(s.get(16..20)?.try_into().ok()?);
+
+        Some(Self {
+            section_count: u16::from_le_bytes(s.get(10..12)?.try_into().ok()?),
+            error_severity: u32::from_le_bytes(s.get(12..16)?.try_into().ok()?).into(),
+            revision,
+            validation_bits,
+            record_length: u32::from_le_bytes(s.get(20..24)?.try_into().ok()?),
+            timestamp: if validation_bits & validation::TIMESTAMP != 0 {
+                Some(Timestamp::from_slice(s.get(24..32)?)?)
+            } else {
+                None
+            },
+            platform_id: if validation_bits & validation::PLATFORM_ID != 0 {
+                Some(Guid::from_bytes(s.get(32..48)?.try_into().ok()?))
+            } else {
+                None
+            },
+            partition_id: if validation_bits & validation::PARTITION_ID != 0 {
+                Some(Guid::from_bytes(s.get(48..64)?.try_into().ok()?))
+            } else {
+                None
+            },
+            creator_id: Guid::from_bytes(s.get(64..80)?.try_into().ok()?),
+            notification_type: Guid::from_bytes(s.get(80..96)?.try_into().ok()?),
+            record_id: u64::from_le_bytes(s.get(96..104)?.try_into().ok()?),
+            flags: u32::from_le_bytes(s.get(104..108)?.try_into().ok()?),
+            persistence_information: u64::from_le_bytes(s.get(108..116)?.try_into().ok()?),
+        })
+    }
+
+    /// Updates the fields of the structures to reflect the actual binary layout of the CPER.
+    pub fn normalize(&mut self) {
+        self.validation_bits = 0;
+        if self.timestamp.is_some() {
+            self.validation_bits |= validation::TIMESTAMP;
+        }
+        if self.platform_id.is_some() {
+            self.validation_bits |= validation::PLATFORM_ID;
+        }
+        if self.partition_id.is_some() {
+            self.validation_bits |= validation::PARTITION_ID;
+        }
+    }
+
+    /// Serializes the CPER Header
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.extend_from_slice(b"CPER");
+        bytes.append(&mut self.revision.to_bytes());
+        bytes.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        bytes.extend_from_slice(&self.section_count.to_le_bytes());
+        bytes.extend_from_slice(&(self.error_severity as u32).to_le_bytes());
+
+        bytes.extend_from_slice(&self.validation_bits.to_le_bytes());
+        bytes.extend_from_slice(&self.record_length.to_le_bytes());
+        bytes.append(&mut self.timestamp.clone().unwrap_or_default().to_bytes());
+        bytes.extend_from_slice(&self.platform_id.unwrap_or_default().to_bytes());
+        bytes.extend_from_slice(&self.partition_id.unwrap_or_default().to_bytes());
+        bytes.extend_from_slice(&self.creator_id.to_bytes());
+        bytes.extend_from_slice(&self.notification_type.to_bytes());
+        bytes.extend_from_slice(&self.record_id.to_le_bytes());
+        bytes.extend_from_slice(&self.flags.to_le_bytes());
+        bytes.extend_from_slice(&self.persistence_information.to_le_bytes());
+        bytes.extend_from_slice(&[0; 12]);
+
+        debug_assert_eq!(bytes.len(), RECORD_HEADER_SIZE);
+        bytes
+    }
+}

--- a/lib/src/cper/revision.rs
+++ b/lib/src/cper/revision.rs
@@ -1,0 +1,34 @@
+#[cfg(not(feature = "std"))]
+use alloc::{fmt, vec, vec::Vec};
+#[cfg(feature = "std")]
+use std::fmt;
+
+/// Revision field is used in several CPER structures
+#[derive(Clone, Default)]
+pub struct Revision {
+    pub major: u8,
+    pub minor: u8,
+}
+
+impl fmt::Display for Revision {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl Revision {
+    pub fn new(major: u8, minor: u8) -> Self {
+        Self { major, minor }
+    }
+
+    pub fn from_slice(s: &[u8]) -> Option<Self> {
+        Some(Self {
+            minor: *s.first()?,
+            major: *s.get(1)?,
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        vec![self.minor, self.major]
+    }
+}

--- a/lib/src/cper/section.rs
+++ b/lib/src/cper/section.rs
@@ -1,0 +1,96 @@
+pub mod fer;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::descr::CperSectionDescriptor;
+use crate::region::Region;
+use fer::FirmwareErrorRecord;
+use uguid::Guid;
+
+pub mod guids {
+    //! GUIDs of the standard CPER sections
+    use uguid::Guid;
+    pub const FW_ERROR_RECORD: Guid = uguid::guid!("81212a96-09ed-4996-9471-8d729c8e69ed");
+}
+
+/// One of the CPER section bodies defined in the UEFI 2.10 Specifications (N.2)
+pub enum CperSectionBody {
+    FirmwareErrorRecord(FirmwareErrorRecord),
+    Unknown(Guid, Vec<u8>),
+}
+
+impl CperSectionBody {
+    /// Parses a section from a slice.
+    pub fn from_slice(guid: uguid::Guid, s: &[u8]) -> Option<Self> {
+        Some(match guid {
+            guids::FW_ERROR_RECORD => {
+                CperSectionBody::FirmwareErrorRecord(fer::FirmwareErrorRecord::from_slice(s)?)
+            }
+            _ => CperSectionBody::Unknown(guid, Vec::from(s)),
+        })
+    }
+
+    /// Returns the GUID associated with section type
+    pub fn guid(&self) -> Guid {
+        match self {
+            CperSectionBody::FirmwareErrorRecord(_) => guids::FW_ERROR_RECORD,
+            CperSectionBody::Unknown(guid, _) => *guid,
+        }
+    }
+
+    /// Returns the expected size of the section in bytes.
+    pub fn len(&self) -> usize {
+        match self {
+            CperSectionBody::FirmwareErrorRecord(fer) => fer.header.len() + fer.payload.len(),
+            CperSectionBody::Unknown(_, data) => data.len(),
+        }
+    }
+
+    /// Converts the section into a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let bytes = match self {
+            CperSectionBody::FirmwareErrorRecord(fer) => fer.to_bytes(),
+            CperSectionBody::Unknown(_, data) => data.clone(),
+        };
+
+        debug_assert_eq!(bytes.len(), self.len());
+        bytes
+    }
+}
+
+/// The descriptor and the body of the CPER Section.
+pub struct CperSection {
+    pub descriptor: CperSectionDescriptor,
+    pub body: CperSectionBody,
+}
+
+impl CperSection {
+    /// Create a CPER Section from a Crash Log record.
+    pub fn from_crashlog_region(region: &Region) -> CperSection {
+        Self::from_body(CperSectionBody::FirmwareErrorRecord(
+            fer::FirmwareErrorRecord::from_crashlog_region(region),
+        ))
+    }
+
+    /// Create a CPER Section from a CPER section body and automatically populated the associated
+    /// descriptor fields.
+    pub fn from_body(body: CperSectionBody) -> Self {
+        Self {
+            descriptor: CperSectionDescriptor {
+                section_type: body.guid(),
+                section_length: body.len() as u32,
+                ..CperSectionDescriptor::default()
+            },
+            body,
+        }
+    }
+
+    /// Converts the section body into a byte vector. The size of the vector matches the section
+    /// length specified in the descriptor.
+    pub fn body_bytes(&self) -> Vec<u8> {
+        let mut bytes = self.body.to_bytes();
+        bytes.resize(self.descriptor.section_length as usize, 0);
+        bytes
+    }
+}

--- a/lib/src/cper/section/fer.rs
+++ b/lib/src/cper/section/fer.rs
@@ -3,36 +3,42 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
-use core::mem;
-#[cfg(feature = "std")]
-use std::mem;
 use uguid::Guid;
 
-pub const RECORD_ID_CRASHLOG: Guid = uguid::guid!("8f87f311-c998-4d9e-a0c4-6065518c4f6d");
+use crate::region::Region;
 
-#[repr(C, packed)]
+pub mod guids {
+    //! GUIDs used to identify the type of the Firmware Error Record payload
+    use uguid::Guid;
+    pub const RECORD_ID_CRASHLOG: Guid = uguid::guid!("8f87f311-c998-4d9e-a0c4-6065518c4f6d");
+}
+
+pub const HEADER_REV1_SIZE: usize = 16;
+pub const HEADER_REV2_SIZE: usize = 32;
+
+/// UEFI 2.10 N.2.10. Firmware Error Record Reference Header
 #[derive(Debug, Clone, Default)]
 pub struct FirmwareErrorRecordHeader {
     pub error_type: u8,
     pub revision: u8,
-    pub reserved: [u8; 6],
     pub record_identifier: u64,
     pub guid: Guid,
 }
 
+/// UEFI 2.10 N.2.10. Firmware Error Record Reference
+#[derive(Debug, Clone, Default)]
 pub struct FirmwareErrorRecord {
     pub header: FirmwareErrorRecordHeader,
     pub payload: Vec<u8>,
 }
 
 impl FirmwareErrorRecordHeader {
+    /// Parses the section header from a slice.
     pub fn from_slice(s: &[u8]) -> Option<Self> {
         let revision = *s.get(1)?;
         Some(Self {
             error_type: *s.first()?,
             revision,
-            reserved: s.get(2..8)?.try_into().ok()?,
             record_identifier: u64::from_le_bytes(s.get(8..16)?.try_into().ok()?),
             guid: if revision >= 2 {
                 Guid::from_bytes(s.get(16..32)?.try_into().ok()?)
@@ -42,32 +48,49 @@ impl FirmwareErrorRecordHeader {
         })
     }
 
+    /// Converts the section header into a byte vector.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.push(self.error_type);
         bytes.push(self.revision);
-        bytes.extend_from_slice(&self.reserved);
+        bytes.extend_from_slice(&[0; 6]);
         bytes.extend_from_slice(&self.record_identifier.to_le_bytes());
         bytes.extend_from_slice(&self.guid.to_bytes());
         bytes
     }
 
-    pub fn size(&self) -> usize {
+    /// Returns the size of the section in bytes
+    pub fn len(&self) -> usize {
         if self.revision >= 2 {
-            mem::size_of::<Self>()
+            HEADER_REV2_SIZE
         } else {
-            mem::size_of::<Self>() - mem::size_of::<u128>()
+            HEADER_REV1_SIZE
         }
     }
 }
 
 impl FirmwareErrorRecord {
+    /// Parses the section from a slice.
     pub fn from_slice(s: &[u8]) -> Option<FirmwareErrorRecord> {
         let header = FirmwareErrorRecordHeader::from_slice(s)?;
-        let payload = Vec::from(s.get(header.size()..)?);
+        let payload = Vec::from(s.get(header.len()..)?);
         Some(Self { header, payload })
     }
 
+    /// Wraps a Crash Log region into a Firmware Error Record
+    pub fn from_crashlog_region(region: &Region) -> Self {
+        Self {
+            header: FirmwareErrorRecordHeader {
+                error_type: 2,
+                revision: 2,
+                guid: guids::RECORD_ID_CRASHLOG,
+                ..FirmwareErrorRecordHeader::default()
+            },
+            payload: region.to_bytes(),
+        }
+    }
+
+    /// Converts the section into a byte vector.
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = self.header.to_bytes();
         bytes.extend_from_slice(&self.payload);

--- a/lib/src/cper/utils.rs
+++ b/lib/src/cper/utils.rs
@@ -1,0 +1,4 @@
+#[inline]
+pub fn bin_to_bcd(byte: u8) -> u8 {
+    (byte / 10) << 4 | (byte % 10)
+}

--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -102,7 +102,7 @@ impl CrashLog {
         let regions: Vec<Region> = cper
             .sections
             .iter()
-            .filter_map(|section| Region::from_cper_section(&section.section))
+            .filter_map(|section| Region::from_cper_section(&section.body))
             .collect();
 
         if regions.is_empty() {
@@ -124,8 +124,8 @@ impl CrashLog {
         }
     }
 
-    /// Exports the [CrashLog] as a sequence of bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    /// Exports the [CrashLog] as a BERT file.
+    pub fn to_bert(&self) -> Vec<u8> {
         let mut berr = Berr::from_crashlog(self).to_bytes();
         let bert = Bert {
             region: 0,
@@ -136,6 +136,12 @@ impl CrashLog {
         let mut bytes = bert.to_bytes();
         bytes.append(&mut berr);
         bytes
+    }
+
+    /// Exports the [CrashLog] as a CPER file that wraps the Crash Log regions into Firmware Error
+    /// Record sections.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        Cper::from_raw_crashlog(self).to_bytes()
     }
 
     /// Returns the register tree representation of the Crash Log record headers.

--- a/lib/src/ffi.rs
+++ b/lib/src/ffi.rs
@@ -56,7 +56,7 @@ pub struct CrashLogs {
 
 /// Opaque type that stores a representation of a Crash Log.
 ///
-/// This structure is created by the [`crashlog_export_to_json`] and [`crashlog_export_to_binary`]
+/// This structure is created by the [`crashlog_export_to_json`] and [`crashlog_export_to_cper`]
 /// functions and must be released using the [`crashlog_release_export`] function.
 ///
 /// The actual content of the structure can be accessed from this structure using the
@@ -108,7 +108,7 @@ pub extern "C" fn crashlog_init() -> *mut CrashLogContext {
 /// Creates a [`CrashLog`] object from a binary blob.
 ///
 /// The binary blob pointed by the `data` argument can be a raw Crash Log region, a BERT
-/// dump, or a CPER dump.
+/// dump, or a CPER record.
 ///
 /// The memory allocated by this function can be freed using the [`crashlog_release`] function.
 ///
@@ -269,7 +269,7 @@ pub unsafe extern "C" fn crashlog_decode(
     }
 }
 
-/// Exports the Crash Log as binary blob.
+/// Exports the Crash Log as a CPER record.
 ///
 /// The memory allocated by this function can be freed using the [`crashlog_release_export`]
 /// function.
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn crashlog_decode(
 /// The `crashlog` pointer must be valid and obtained using one of the `crashlog_read_*()`
 /// functions.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn crashlog_export_to_binary(
+pub unsafe extern "C" fn crashlog_export_to_cper(
     context: *mut CrashLogContext,
     crashlog: *const CrashLog,
 ) -> *mut CrashLogExport {
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn crashlog_export_to_json(
 /// calling the [`crashlog_init`] function.
 ///
 /// The `export` pointer must be obtained using the [`crashlog_export_to_json`] function or the
-/// [`crashlog_export_to_binary`] function.
+/// [`crashlog_export_to_cper`] function.
 ///
 /// The `buffer` pointer must point to a valid writable memory region of `buffer_size` bytes.
 /// The data written to this buffer is not nul-terminated.

--- a/lib/src/ffi/tests.rs
+++ b/lib/src/ffi/tests.rs
@@ -98,7 +98,7 @@ fn ffi_export() {
     unsafe {
         let ctx = crashlog_init();
         let crashlog = crashlog_read_from_buffer(ctx, blob.as_ptr(), blob.len());
-        let export = crashlog_export_to_binary(ctx, crashlog);
+        let export = crashlog_export_to_cper(ctx, crashlog);
         let mut data: Vec<u8> = Vec::new();
 
         let mut buffer = [0u8; 32];

--- a/lib/src/region.rs
+++ b/lib/src/region.rs
@@ -3,7 +3,7 @@
 
 //! Provides access to the records stored in a Crash Log region.
 
-use crate::cper::{CperSection, fer};
+use crate::cper::section::{CperSectionBody, fer};
 use crate::error::Error;
 use crate::header::Header;
 use crate::record::Record;
@@ -20,11 +20,11 @@ pub struct Region {
 }
 
 impl Region {
-    pub(crate) fn from_cper_section(section: &CperSection) -> Option<Self> {
+    pub(crate) fn from_cper_section(section: &CperSectionBody) -> Option<Self> {
         match section {
-            CperSection::FirmwareErrorRecord(fer) => {
+            CperSectionBody::FirmwareErrorRecord(fer) => {
                 let guid = fer.header.guid;
-                if guid == fer::RECORD_ID_CRASHLOG {
+                if guid == fer::guids::RECORD_ID_CRASHLOG {
                     Region::from_slice(&fer.payload).ok()
                 } else {
                     log::info!("Ignoring unknown Firmware Error Record: {}", guid);


### PR DESCRIPTION
Storing HW error logs as UEFI CPER records is a more "standard" approach than saving them as ACPI BERT tables (for instance, WHEA uses CPER format).

This change updates the overall toolchain to encapsulate the Crash Log records as CPER Firmware Error Records whenever they need to be serialized.

The BERT export function is still present but has been renamed.