### PR TITLE
collateral: include `GNR-SP` target info

### DIFF
--- a/lib/collateral/GNR/SP/all/all/crashlog/target_info.json
+++ b/lib/collateral/GNR/SP/all/all/crashlog/target_info.json
@@ -1,0 +1,20 @@
+{
+    "fullname": "graniterapids",
+    "product": "GNR",
+    "product_id": "0x2F",
+    "subproducts": [
+        {
+            "product": "RWC",
+            "stepping": "all",
+            "variant": "all"
+        }
+    ],
+    "variant": "SP",
+    "die_id": {
+        "0": "io0",
+        "4": "io1",
+        "9": "compute0",
+        "10": "compute1",
+        "11": "compute2"
+    }
+}

--- a/lib/tests/crashlog.rs
+++ b/lib/tests/crashlog.rs
@@ -88,7 +88,7 @@ fn legacy_type0_box() {
     assert_eq!(product_id.kind, NodeType::Field { value: 0x79 });
 
     let box_revision = root
-        .get_by_path("processors.cpu1.die10.pcore.hdr.version.revision")
+        .get_by_path("processors.cpu1.compute1.pcore.hdr.version.revision")
         .unwrap();
 
     assert_eq!(box_revision.kind, NodeType::Field { value: 0x81 });


### PR DESCRIPTION
This patch includes the `target_info` file for graniterapids SP product.