### PR TITLE
lib: include `parent_header` in current `Record` context.

### DIFF
--- a/lib/src/crashlog.rs
+++ b/lib/src/crashlog.rs
@@ -14,7 +14,6 @@ use alloc::{collections::VecDeque, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
-use crate::header::HeaderType;
 use crate::header::record_types;
 
 /// Set of all the Crash Log records captured on a platform.
@@ -48,15 +47,7 @@ impl CrashLog {
 
                 match Region::from_slice(payload) {
                     Ok(mut region) => {
-                        if let HeaderType::Type6 {
-                            socket_id, die_id, ..
-                        }
-                        | HeaderType::Type0LegacyServer {
-                            socket_id, die_id, ..
-                        } = record.header.header_type
-                        {
-                            region.set_socket_and_die_ids(socket_id, die_id)
-                        };
+                        region.set_child_context(&record.header);
                         queue.push_front(region)
                     }
                     Err(err) => log::warn!("Invalid region in Box record: {err}"),

--- a/lib/src/record.rs
+++ b/lib/src/record.rs
@@ -24,10 +24,8 @@ pub struct Record {
 /// Additional data provided to a Crash Log record
 #[derive(Clone, Default)]
 pub struct Context {
-    /// Die ID of the record
-    pub die_id: Option<u8>,
-    /// Socket ID of the record
-    pub socket_id: Option<u8>,
+    /// Header of the parent record
+    pub parent_header: Option<Header>,
 }
 
 impl Record {

--- a/lib/src/region.rs
+++ b/lib/src/region.rs
@@ -35,10 +35,9 @@ impl Region {
         }
     }
 
-    pub(crate) fn set_socket_and_die_ids(&mut self, socket_id: u8, die_id: u8) {
+    pub(crate) fn set_child_context(&mut self, hdr: &Header) {
         for record in self.records.iter_mut() {
-            record.context.socket_id = Some(socket_id);
-            record.context.die_id = Some(die_id);
+            record.context.parent_header = Some(hdr.clone());
         }
     }
 

--- a/lib/tests/crashlog.rs
+++ b/lib/tests/crashlog.rs
@@ -82,7 +82,7 @@ fn legacy_type0_box() {
     let root = crashlog.decode(&mut cm);
 
     let product_id = root
-        .get_by_path("processors.cpu1.die10.mca.hdr.version.product_id")
+        .get_by_path("processors.cpu1.compute1.mca.hdr.version.product_id")
         .unwrap();
 
     assert_eq!(product_id.kind, NodeType::Field { value: 0x79 });


### PR DESCRIPTION
In situations where there is a `Box` Record with a HeaderType 6, the records that are inside of the `Box` should inherit the socket and die name in the case that they don't have any socket or die defined.

As it is valid that the records inside of the `Box` may have a different `ProductID` than the `Box` itself, the intention is that the records in the Box can inherit the name of the die and socket id of the box and the name comes directly from the product collateral.

In this patch the current behaviour of the decoder of the records inside the Box will change, and in case those records don't have any `die` name defined, the decoder will check if the `Box` record has a die name defined and will use it in the `root_node` hierarchy.