### PR TITLE
lib: update the `errata` server legacy header product ID values

### DIFF
--- a/lib/src/errata.rs
+++ b/lib/src/errata.rs
@@ -31,11 +31,17 @@ pub struct Errata {
     pub core_record_size_bytes: bool,
 }
 
+const GNR_SP_PRODUCT_ID: u32 = 0x2f;
+const SRF_SP_PRODUCT_ID: u32 = 0x82;
+pub const SERVER_LEGACY_PRODUCT_IDS: [u32; 2] = [GNR_SP_PRODUCT_ID, SRF_SP_PRODUCT_ID];
+
 impl Errata {
     pub fn from_version(version: &Version) -> Self {
-        let type0_legacy_server = version.header_type == 0 && version.product_id == 0x2f;
+        let type0_legacy_server =
+            version.header_type == 0 && SERVER_LEGACY_PRODUCT_IDS.contains(&version.product_id);
         let type0_legacy_server_box =
             type0_legacy_server && version.record_type == record_types::PCORE;
+
         let core_record_size_bytes = !type0_legacy_server
             && ((version.record_type == record_types::ECORE && version.product_id < 0x96)
                 || (version.record_type == record_types::PCORE && version.product_id < 0x71));

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -5,7 +5,7 @@
 
 #[cfg(feature = "collateral_manager")]
 use crate::collateral::{CollateralManager, CollateralTree, ItemPath, PVSS};
-use crate::errata::Errata;
+use crate::errata::{Errata, SERVER_LEGACY_PRODUCT_IDS};
 use crate::error::Error;
 use crate::node::Node;
 #[cfg(not(feature = "std"))]
@@ -551,7 +551,8 @@ impl Version {
     }
 
     pub fn into_errata(&self) -> Errata {
-        let type0_legacy_server = self.header_type == 0 && self.product_id == 0x2f;
+        let type0_legacy_server =
+            self.header_type == 0 && SERVER_LEGACY_PRODUCT_IDS.contains(&self.product_id);
         let type0_legacy_server_box = type0_legacy_server && self.record_type == 0x4;
         let core_record_size_bytes = !type0_legacy_server
             && ((self.record_type == record_types::ECORE && self.product_id < 0x96)


### PR DESCRIPTION
This patch updates the values for the current products that contain a legacy type 0 header.