### PR TITLE
lib: include `SRF-SP` target info in collateral

### DIFF
--- a/lib/collateral/SRF/SP/all/all/crashlog/target_info.json
+++ b/lib/collateral/SRF/SP/all/all/crashlog/target_info.json
@@ -1,0 +1,13 @@
+{
+    "fullname": "sierraforest",
+    "product": "SRF",
+    "product_id": "0x82",
+    "variant": "SP",
+    "die_id": {
+        "0": "io0",
+        "4": "io1",
+        "9": "compute0",
+        "10": "compute1",
+        "11": "compute2"
+    }
+}


### PR DESCRIPTION
This patch includes the target info file in the collateral tree for `SRF` product.