### PR TITLE
collateral: include `CMT` target_info file

### DIFF
--- a/lib/collateral/CMT/all/all/all/crashlog/target_info.json
+++ b/lib/collateral/CMT/all/all/all/crashlog/target_info.json
@@ -1,0 +1,4 @@
+{
+    "product": "CMT",
+    "product_id": "0x6C"
+}


### PR DESCRIPTION
This patch includes the crestmont target_info.json file, needed to recognize Crash Log records coming from `CMT` products.