### PR TITLE
lib: preserve extra CPER sections

### DIFF
--- a/lib/src/cper.rs
+++ b/lib/src/cper.rs
@@ -73,6 +73,10 @@ impl Cper {
             cper.append_section(section);
         }
 
+        for extra_cper_section in crashlog.metadata.extra_cper_sections.iter() {
+            cper.append_section(CperSection::from_body(extra_cper_section.clone()));
+        }
+
         cper
     }
 

--- a/lib/src/cper/section.rs
+++ b/lib/src/cper/section.rs
@@ -15,6 +15,7 @@ pub mod guids {
 }
 
 /// One of the CPER section bodies defined in the UEFI 2.10 Specifications (N.2)
+#[derive(Clone)]
 pub enum CperSectionBody {
     FirmwareErrorRecord(FirmwareErrorRecord),
     Unknown(Guid, Vec<u8>),

--- a/lib/src/cper/tests.rs
+++ b/lib/src/cper/tests.rs
@@ -37,7 +37,12 @@ fn cl_from_cper() {
         }
     }
 
+    assert_eq!(crashlog.metadata.extra_cper_sections.len(), 2);
     assert_eq!(records.len(), 3);
+
+    let cper_bytes = crashlog.to_bytes();
+    let cper = Cper::from_slice(&cper_bytes).unwrap();
+    assert_eq!(cper.record_header.section_count, 5);
 }
 
 #[test]

--- a/lib/src/extract/efi.rs
+++ b/lib/src/extract/efi.rs
@@ -98,6 +98,7 @@ impl CrashLog {
                 })
                 .inspect_err(|err| log::warn!("Cannot get time: {err}"))
                 .ok(),
+            ..Default::default()
         };
 
         Ok(crashlog)

--- a/lib/src/extract/event_log.rs
+++ b/lib/src/extract/event_log.rs
@@ -160,6 +160,7 @@ fn metadata_from_evt_values(
             minute: time.wMinute as u8,
         }),
         computer: unsafe { computer.Anonymous.StringVal.to_string().ok() },
+        ..Default::default()
     })
 }
 

--- a/lib/src/metadata.rs
+++ b/lib/src/metadata.rs
@@ -4,15 +4,24 @@
 //! Information extracted alongside the Crash Log records.
 
 #[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
 use alloc::{fmt, string::String};
 #[cfg(feature = "std")]
 use std::fmt;
 
+use crate::cper::CperSectionBody;
+
 /// Crash Log Metadata
 #[derive(Default)]
 pub struct Metadata {
+    /// Name of the computer where the Crash Log has been extracted from.
     pub computer: Option<String>,
+    /// Time of the extraction
     pub time: Option<Time>,
+    /// When the Crash Log is extracted from a CPER, this field stores the extra CPER sections that
+    /// could be read from the CPER structure.
+    pub extra_cper_sections: Vec<CperSectionBody>,
 }
 
 /// Crash Log Extraction Time


### PR DESCRIPTION
The input CPER may include sections that don't represent Crash Log regions.
This change allows these sections to be preserved during the extraction flow.