### PR TITLE
lib: remove pub prefix from private extraction functions/structs

### DIFF
--- a/lib/src/errata.rs
+++ b/lib/src/errata.rs
@@ -33,7 +33,7 @@ pub struct Errata {
 
 const GNR_SP_PRODUCT_ID: u32 = 0x2f;
 const SRF_SP_PRODUCT_ID: u32 = 0x82;
-pub const SERVER_LEGACY_PRODUCT_IDS: [u32; 2] = [GNR_SP_PRODUCT_ID, SRF_SP_PRODUCT_ID];
+pub(crate) const SERVER_LEGACY_PRODUCT_IDS: [u32; 2] = [GNR_SP_PRODUCT_ID, SRF_SP_PRODUCT_ID];
 
 impl Errata {
     pub fn from_version(version: &Version) -> Self {

--- a/lib/src/extract/efi.rs
+++ b/lib/src/extract/efi.rs
@@ -62,7 +62,7 @@ fn find_acpi_tables() -> Option<AcpiTables<IdentityMapped>> {
     })
 }
 
-pub fn find_bert() -> Result<Bert, Error> {
+fn find_bert() -> Result<Bert, Error> {
     let tables = find_acpi_tables().ok_or(Error::NoCrashLogFound)?;
     tables
         .find_table::<Bert>()

--- a/lib/src/extract/event_log.rs
+++ b/lib/src/extract/event_log.rs
@@ -14,7 +14,7 @@ use windows::Win32::System::EventLog::*;
 use windows::Win32::System::Time::FileTimeToSystemTime;
 use windows::core::*;
 
-pub struct EvtHandle(EVT_HANDLE);
+struct EvtHandle(EVT_HANDLE);
 
 impl Drop for EvtHandle {
     fn drop(&mut self) {
@@ -62,7 +62,7 @@ fn evt_next(result_set: &EvtHandle, count: usize) -> Result<Vec<EvtHandle>> {
         .collect())
 }
 
-pub struct EvtRenderedValues {
+struct EvtRenderedValues {
     buffer: *mut u8,
     layout: Layout,
     property_count: u32,


### PR DESCRIPTION
These functions don't need to be exposed externally.