### PR TITLE
lib: enable doc_cfg only when building documentation

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(doc_cfg)]
+#![cfg_attr(doc, feature(doc_cfg))]
 
 //! ## Getting Started
 //!


### PR DESCRIPTION
This change enables the doc_cfg feature only when building the documentation as it is not needed in other contexts. It removes the following warning reported by clippy:

    warning: feature `doc_cfg` is declared but not used
     --> src/lib.rs:5:12
      |
    5 | #![feature(doc_cfg)]
      |            ^^^^^^^
      |
      = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default