### PR TITLE
app: fix record type format specs

### DIFF
--- a/app/src/info.rs
+++ b/app/src/info.rs
@@ -22,7 +22,7 @@ fn compact<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Result
             let record_type = if let Ok(record_type) = record.header.record_type() {
                 record_type.into()
             } else {
-                format!("{:#02x}", record.header.version.record_type)
+                format!("{:#04x}", record.header.version.record_type)
             };
 
             let checksum = record
@@ -117,7 +117,7 @@ fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Resul
             let record_type = if let Ok(record_type) = record.header.record_type() {
                 record_type.into()
             } else {
-                format!("{:#02x}", record.header.version.record_type)
+                format!("{:#04x}", record.header.version.record_type)
             };
 
             let checksum = record

--- a/efi/src/decode.rs
+++ b/efi/src/decode.rs
@@ -61,7 +61,7 @@ pub fn info(input_path: &Path) -> Result<(), uefi::Error> {
             let record_type = if let Ok(record_type) = record.header.record_type() {
                 record_type.into()
             } else {
-                format!("{:#02x}", record.header.version.record_type)
+                format!("{:#04x}", record.header.version.record_type)
             };
 
             let checksum = record


### PR DESCRIPTION
Fixes the following warning message reported by clippy:

    warning: format width has no effect on the output for this format trait
       --> src/decode.rs:64:26

        |
     64 |                 format!("{:#02x}", record.header.version.record_type)
        |                          ^^^^^^^