### PR TITLE
treewide: make project buildable with stable toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Lightweight Crash Log Framework is a reference implementation designed for
 decoding and extracting data using Intel® Crash Log Technology. It can function
 as a standalone application or be integrated into other applications.
 
->[!WARNING] 
+>[!WARNING]
 > This tool supports a limited number of platforms utilizing Crash Log
 > technology. However, it can decode the common Crash Log header structure on
 > unsupported platforms. We are actively working to expand platform support.
@@ -52,10 +52,6 @@ the EFI shell.
 
    Before building the project, install the Rust toolchain using
    [rustup](https://rustup.rs/).
-
-> [!NOTE]
-> The nightly toolchain is required to build this project. Install it with:
-> `rustup default nightly`
 
 2. **Install the CLI Application**
 

--- a/app/README.md
+++ b/app/README.md
@@ -8,9 +8,8 @@ records directly from the terminal.
 To build and install the application, follow these steps:
 
 1. **Build the Application in Release Mode:**
-  
+
   ```
-  $ rustup default nightly
   $ cargo build --release
   ```
 

--- a/app/rust-toolchain.toml
+++ b/app/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/efi/Cargo.toml
+++ b/efi/Cargo.toml
@@ -10,7 +10,6 @@ name = "iclg"
 path = "src/main.rs"
 
 [dependencies]
-acpi = "5.0"
 log = "0.4"
 
 [dependencies.intel_crashlog]
@@ -31,6 +30,10 @@ features = [
     "logger",
     "global_allocator"
 ]
+
+[dependencies.acpi]
+version = "5.1"
+default-features = false
 
 [dependencies.serde_json]
 version = "1.0"

--- a/efi/rust-toolchain.toml
+++ b/efi/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "nightly"
 targets = ["x86_64-unknown-uefi"]

--- a/efi/src/main.rs
+++ b/efi/src/main.rs
@@ -3,7 +3,6 @@
 
 #![no_main]
 #![no_std]
-#![feature(iter_intersperse)]
 
 mod args;
 mod decode;

--- a/efi/src/pager/render.rs
+++ b/efi/src/pager/render.rs
@@ -18,19 +18,14 @@ impl Pager {
                 return Ok(());
             }
 
-            for s in line
-                .split(&self.search_pattern)
-                .intersperse(&self.search_pattern)
-            {
-                self.output.set_color(
-                    if s == self.search_pattern {
-                        Color::Yellow
-                    } else {
-                        Color::LightGray
-                    },
-                    Color::Black,
-                )?;
-                let _ = write!(self.output, "{s}");
+            for s in line.split_inclusive(&self.search_pattern) {
+                self.output.set_color(Color::LightGray, Color::Black)?;
+                let _ = write!(self.output, "{}", s.trim_end_matches(&self.search_pattern));
+
+                if s.ends_with(&self.search_pattern) {
+                    self.output.set_color(Color::Yellow, Color::Black)?;
+                    let _ = write!(self.output, "{}", &self.search_pattern);
+                }
             }
 
             self.output.set_color(Color::LightGray, Color::Black)?;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -48,9 +48,12 @@ std = [
 cargo-emit = "0.2"
 
 [dependencies]
-acpi = "5.1"
 uguid = "2.2"
 log = "0.4"
+
+[dependencies.acpi]
+version = "5.1"
+default-features = false
 
 [dependencies.serde]
 version = "1.0"

--- a/lib/rust-toolchain.toml
+++ b/lib/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(doc, feature(doc_cfg))]
 
 //! ## Getting Started
 //!

--- a/lib/tests/record.rs
+++ b/lib/tests/record.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 use intel_crashlog::header::{RecordSize, Version};
 use intel_crashlog::prelude::*;
-use std::assert_matches;
 use std::fs;
 use std::path::Path;
 
@@ -195,10 +194,11 @@ fn invalid_decode_defs() {
     let csv = "name;offset;size;description;bitfield
 foo;0;64;;0
 foo.bar;=2+2;8;;0";
-    assert_matches!(
+
+    assert!(matches!(
         record.decode_with_csv(csv.as_bytes(), 0),
         Err(Error::ParseIntError(_))
-    );
+    ));
 
     let csv = "fullname;size;offset
 aaa;4;8


### PR DESCRIPTION
In order to make the crates of this project buildable with the stable rust toolchain, the following changes have been made:

- Disabled the alloc feature of the acpi crate.
- Disabled the doc_cfg unstable feature.
- Disabled the iter_intersperse unstable feature.