### PR TITLE
lib: add support for clear command

### DIFF
--- a/app/src/control.rs
+++ b/app/src/control.rs
@@ -7,6 +7,10 @@ pub fn trigger(sources: Vec<CrashLogSource>) -> Result<(), Error> {
     control_command(sources, CrashLogSource::trigger)
 }
 
+pub fn clear(sources: Vec<CrashLogSource>) -> Result<(), Error> {
+    control_command(sources, CrashLogSource::clear)
+}
+
 pub fn enable(sources: Vec<CrashLogSource>) -> Result<(), Error> {
     control_command(sources, CrashLogSource::enable)
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -72,6 +72,11 @@ enum Command {
         #[arg(short, long, value_delimiter = ',')]
         sources: Vec<CrashLogSource>,
     },
+    /// Clear the Crash Log storages
+    Clear {
+        #[arg(short, long, value_delimiter = ',')]
+        sources: Vec<CrashLogSource>,
+    },
     /// Unpack the Crash Log records stored in the input file
     Unpack { input_files: Vec<PathBuf> },
     /// Triage the Crash Log records stored in the input files
@@ -96,6 +101,7 @@ impl Command {
             } => info::info(&cm, input_files, *format),
             Command::List => list::list(),
             Command::Trigger { sources } => control::trigger(sources.clone())?,
+            Command::Clear { sources } => control::clear(sources.clone())?,
             Command::Unpack { input_files } => {
                 for input_file in input_files {
                     if let Err(err) = unpack::unpack(input_file) {

--- a/lib/src/metadata.rs
+++ b/lib/src/metadata.rs
@@ -11,12 +11,15 @@ use alloc::{fmt, string::String};
 use std::fmt;
 
 use crate::cper::CperSectionBody;
+use crate::source::CrashLogSource;
 
 /// Crash Log Metadata
 #[derive(Default)]
 pub struct Metadata {
     /// Name of the computer where the Crash Log has been extracted from.
     pub computer: Option<String>,
+    /// Name of the source where the Crash Log has been extracted from.
+    pub source: Option<CrashLogSource>,
     /// Time of the extraction
     pub time: Option<Time>,
     /// When the Crash Log is extracted from a CPER, this field stores the extra CPER sections that
@@ -35,11 +38,19 @@ pub struct Time {
 
 impl fmt::Display for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match (self.computer.as_ref(), self.time.as_ref()) {
-            (Some(computer), Some(time)) => write!(f, "{computer}-{time}"),
-            (None, Some(time)) => write!(f, "{time}"),
-            (Some(computer), None) => write!(f, "{computer}"),
-            (None, None) => write!(f, "unnamed"),
+        match (
+            self.computer.as_ref(),
+            self.source.as_ref(),
+            self.time.as_ref(),
+        ) {
+            (Some(computer), Some(source), Some(time)) => write!(f, "{computer}-{source}-{time}"),
+            (Some(computer), None, Some(time)) => write!(f, "{computer}-{time}"),
+            (None, None, Some(time)) => write!(f, "{time}"),
+            (None, Some(source), Some(time)) => write!(f, "{source}-{time}"),
+            (Some(computer), None, None) => write!(f, "{computer}"),
+            (Some(computer), Some(source), None) => write!(f, "{computer}-{source}"),
+            (None, Some(source), None) => write!(f, "{source}"),
+            (None, None, None) => write!(f, "unnamed"),
         }
     }
 }

--- a/lib/src/source.rs
+++ b/lib/src/source.rs
@@ -182,6 +182,15 @@ impl CrashLogSource {
         }
     }
 
+    /// Clears the Crash Log storage on this source
+    #[cfg(feature = "control_commands")]
+    pub fn clear(&self) -> Result<(), Error> {
+        match self {
+            Self::PmtDevice(dev) => Pmt::default().clear(dev),
+            _ => Err(Error::Unsupported),
+        }
+    }
+
     /// Enable the Crash Log collection on this source
     #[cfg(feature = "control_commands")]
     pub fn enable(&self) -> Result<(), Error> {

--- a/lib/src/source.rs
+++ b/lib/src/source.rs
@@ -158,11 +158,19 @@ impl CrashLogSource {
     /// Returns the Crash Log extracted from the platform using the current Crash Log source
     #[cfg(feature = "extraction")]
     pub fn extract(&self) -> Result<Vec<CrashLog>, Error> {
-        match self {
+        let mut crashlogs = match self {
             Self::Acpi => Acpi::default().extract().map(|crashlog| vec![crashlog]),
             Self::PmtDevice(dev) => Pmt::default().extract(dev),
             Self::EventLog => EventLog::default().extract(),
+        };
+
+        if let Ok(ref mut crashlogs) = crashlogs {
+            for crashlog in crashlogs.iter_mut() {
+                crashlog.metadata.source = Some(self.clone());
+            }
         }
+
+        crashlogs
     }
 
     /// Triggers an on-demand Crash Log collection on this source

--- a/lib/src/source/capability.rs
+++ b/lib/src/source/capability.rs
@@ -15,6 +15,8 @@ pub enum Capability {
     Trigger,
     /// Enabling/Disabling of Crash Log collection flow
     EnableDisable,
+    /// Clearing of the Crash Log storage
+    Clear,
 }
 
 impl fmt::Display for Capability {
@@ -23,6 +25,7 @@ impl fmt::Display for Capability {
             Self::Extract => write!(f, "extract"),
             Self::Trigger => write!(f, "trigger"),
             Self::EnableDisable => write!(f, "enable/disable"),
+            Self::Clear => write!(f, "clear"),
         }
     }
 }

--- a/lib/src/source/pmt.rs
+++ b/lib/src/source/pmt.rs
@@ -98,6 +98,19 @@ impl Pmt {
         Err(Error::Unsupported)
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn clear(&self, dev: &PmtDeviceId) -> Result<(), Error> {
+        for endpoint in self.sysfs.get_endpoints(dev) {
+            endpoint.clear()?;
+        }
+        Ok(())
+    }
+
+    #[cfg(all(not(target_os = "linux"), feature = "control_commands"))]
+    pub fn clear(&self, _dev: &PmtDeviceId) -> Result<(), Error> {
+        Err(Error::Unsupported)
+    }
+
     #[cfg(all(target_os = "linux", feature = "control_commands"))]
     pub fn trigger(&self, dev: &PmtDeviceId) -> Result<(), Error> {
         for endpoint in self.sysfs.get_endpoints(dev) {

--- a/lib/src/source/pmt/sysfs.rs
+++ b/lib/src/source/pmt/sysfs.rs
@@ -209,7 +209,11 @@ impl PmtSysFs {
         let mut crashlogs = Vec::new();
 
         for endpoint in self.get_endpoints(dev) {
-            crashlogs.push(endpoint.extract()?);
+            match endpoint.extract() {
+                Ok(crashlog) => crashlogs.push(crashlog),
+                Err(Error::EmptyRegion) => (),
+                Err(err) => return Err(err),
+            }
         }
 
         Ok(crashlogs)

--- a/lib/src/source/pmt/sysfs.rs
+++ b/lib/src/source/pmt/sysfs.rs
@@ -248,6 +248,11 @@ impl PmtSysFsEndpoint {
     }
 
     #[cfg(feature = "control_commands")]
+    pub fn clear(&self) -> Result<(), Error> {
+        self.write_command("clear", b"1")
+    }
+
+    #[cfg(feature = "control_commands")]
     pub fn enable_disable(&self, enable: bool) -> Result<(), Error> {
         self.write_command("enable", if enable { b"1" } else { b"0" })
     }
@@ -283,6 +288,10 @@ impl PmtSysFsEndpoint {
 
         if self.path.join("enable").exists() {
             capabilities.insert(Capability::EnableDisable);
+        }
+
+        if self.path.join("clear").exists() {
+            capabilities.insert(Capability::Clear);
         }
 
         capabilities


### PR DESCRIPTION
Some sources support clearing the Crash Log storages. These changes
allow the clear command to be triggered from the CLI:

        $ iclg clear