### PR TITLE
app: make info command dispaly extra CPER sections

### DIFF
--- a/app/src/info.rs
+++ b/app/src/info.rs
@@ -69,46 +69,32 @@ fn compact<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Result
 
     table.render();
 
+    if !crashlog.metadata.extra_cper_sections.is_empty() {
+        println!();
+
+        let mut table = Table::from(["#", "CPER Section GUID", "Length", "Description"]);
+
+        for (i, section) in crashlog.metadata.extra_cper_sections.iter().enumerate() {
+            table.append_row(Row::from([
+                i.to_string(),
+                section.guid().to_string(),
+                section.len().to_string(),
+                section.to_string(),
+            ]));
+        }
+
+        table.render();
+    }
+
     Ok(())
 }
 
 fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Result<(), Error> {
     let crashlog = CrashLog::from_slice(&std::fs::read(input)?)?;
 
-    // Column widths
-    let region_idx_width = 8;
-    let record_idx_width = 8;
-    let record_type_width = 16;
-    let revision_width = 8;
-    let product_width = 14;
-    let size_width = 10;
-    let skt_width = 8;
-    let checksum_width = 12;
-    let die_width = 10;
+    println!("### Crash Log Records\n");
 
-    // Header
-    println!(
-        "| {1:<region_idx_width$} \
-         | {2:<record_idx_width$} \
-         | {3:<record_type_width$} \
-         | {4:<revision_width$} \
-         | {5:<product_width$} \
-         | {6:<size_width$} \
-         | {7:<skt_width$} \
-         | {8:<checksum_width$} \
-         | {9:<die_width$} \
-         |\n\
-         | {0:-<region_idx_width$} \
-         | {0:-<record_idx_width$} \
-         | {0:-<record_type_width$} \
-         | {0:-<revision_width$} \
-         | {0:-<product_width$} \
-         | {0:-<size_width$} \
-         | {0:-<skt_width$} \
-         | {0:-<checksum_width$} \
-         | {0:-<die_width$} \
-         |",
-        "",
+    let mut table = Table::from([
         "Region",
         "Record",
         "Record Type",
@@ -118,7 +104,7 @@ fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Resul
         "Socket",
         "Checksum",
         "Die",
-    );
+    ]);
 
     for (i, region) in crashlog.regions.iter().enumerate() {
         for (j, record) in region.records.iter().enumerate() {
@@ -137,7 +123,8 @@ fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Resul
 
             let checksum = record
                 .checksum()
-                .map_or("", |check| if check { "Valid" } else { "Invalid" });
+                .map_or("", |check| if check { "Valid" } else { "Invalid" })
+                .to_string();
 
             let die = if let Some(die_id) = record.header.die(cm) {
                 die_id
@@ -152,21 +139,39 @@ fn markdown<T: CollateralTree>(cm: &CollateralManager<T>, input: &Path) -> Resul
             let record_size = record.header.record_size();
             let socket_id = record.header.socket_id();
 
-            // Populate the table
-            println!(
-                "| {i:<region_idx_width$} \
-                 | {j:<record_idx_width$} \
-                 | {record_type:<record_type_width$} \
-                 | {revision:<revision_width$} \
-                 | {product:<product_width$} \
-                 | {record_size:<size_width$} \
-                 | {socket_id:<skt_width$} \
-                 | {checksum:<checksum_width$} \
-                 | {die:<die_width$} \
-                 |"
-            );
+            table.append_row(Row::from([
+                i.to_string(),
+                j.to_string(),
+                record_type,
+                revision.to_string(),
+                product,
+                record_size.to_string(),
+                socket_id.to_string(),
+                checksum,
+                die.to_string(),
+            ]));
         }
     }
+
+    table.render_markdown();
+
+    if !crashlog.metadata.extra_cper_sections.is_empty() {
+        println!("\n### Extra CPER Sections\n");
+
+        let mut table = Table::from(["#", "CPER Section GUID", "Length", "Description"]);
+
+        for (i, section) in crashlog.metadata.extra_cper_sections.iter().enumerate() {
+            table.append_row(Row::from([
+                i.to_string(),
+                section.guid().to_string(),
+                section.len().to_string(),
+                section.to_string(),
+            ]));
+        }
+
+        table.render_markdown();
+    }
+
     Ok(())
 }
 

--- a/app/src/table.rs
+++ b/app/src/table.rs
@@ -107,4 +107,37 @@ impl Table {
             println!();
         }
     }
+
+    pub fn render_markdown(&self) {
+        print!("|");
+        for column in self.columns.iter() {
+            print!(" {:width$}|", column.title, width = column.width + 2);
+        }
+        println!();
+
+        print!("|");
+        for column in self.columns.iter() {
+            print!(" {:->width$}|", " ", width = column.width + 2);
+        }
+        println!();
+
+        for row in self.rows.iter() {
+            print!("|");
+            for (i, cell) in row.cells.iter().enumerate() {
+                let Some(column) = self.columns.get(i) else {
+                    break;
+                };
+
+                let width = column.width + 2;
+                print!(" ");
+                match column.alignment {
+                    Alignment::Left => print!("{:width$}", cell),
+                    Alignment::Right => print!("{:>width$} ", cell, width = width - 1),
+                    Alignment::Center => print!("{:^width$}", cell),
+                }
+                print!("|");
+            }
+            println!();
+        }
+    }
 }

--- a/lib/src/cper/section.rs
+++ b/lib/src/cper/section.rs
@@ -4,7 +4,9 @@
 pub mod fer;
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
+#[cfg(feature = "std")]
+use std::fmt;
 
 use super::descr::CperSectionDescriptor;
 use crate::region::Region;
@@ -60,6 +62,15 @@ impl CperSectionBody {
 
         debug_assert_eq!(bytes.len(), self.len());
         bytes
+    }
+}
+
+impl fmt::Display for CperSectionBody {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::FirmwareErrorRecord(fer) => write!(f, "Firmware Error Record - {fer}"),
+            Self::Unknown(_, _) => write!(f, "Unknown"),
+        }
     }
 }
 

--- a/lib/src/cper/section/fer.rs
+++ b/lib/src/cper/section/fer.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{fmt, vec::Vec};
+#[cfg(feature = "std")]
+use std::fmt;
 use uguid::Guid;
 
 use crate::region::Region;
@@ -32,6 +34,15 @@ pub struct FirmwareErrorRecordHeader {
 pub struct FirmwareErrorRecord {
     pub header: FirmwareErrorRecordHeader,
     pub payload: Vec<u8>,
+}
+
+impl fmt::Display for FirmwareErrorRecord {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.header.guid {
+            guids::RECORD_ID_CRASHLOG => write!(f, "Intel Crash Log Region"),
+            _ => write!(f, "{}", self.header.guid),
+        }
+    }
 }
 
 impl FirmwareErrorRecordHeader {


### PR DESCRIPTION
When the input file contains extra CPER sections (eg. other than FERs containing Intel Crash Log records), the info command now displays an additional table listing the section's GUID and descriptions:

    $ iclg info cper.whea
      #   Record Type  Rev.  Product  Size  Skt  Checksum  Die
    ----- ------------ ----- -------- ----- ---- --------- ----
     0-0  Punit           16 0x017       28    0
     1-0  PMC              3 0x00c     2560    0
     2-0  PMC_TRACE        1 0x00c      512    0

    #  CPER Section GUID                     Length  Description
    -- ------------------------------------- ------- -------------------------------------------------------------
    0  81212a96-09ed-4996-9471-8d729c8e69ed  4128    Firmware Error Record - 26d769a7-c31a-43d0-9378-3c6c872eea4d
    1  81212a96-09ed-4996-9471-8d729c8e69ed  3552    Firmware Error Record - 024508e0-d564-42ed-b236-580d542bc9d6