### PR TITLE
lib: gate `clear` command and `Write` behind `control_commands` feature

### DIFF
--- a/lib/src/source/pmt.rs
+++ b/lib/src/source/pmt.rs
@@ -98,7 +98,7 @@ impl Pmt {
         Err(Error::Unsupported)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "control_commands"))]
     pub fn clear(&self, dev: &PmtDeviceId) -> Result<(), Error> {
         for endpoint in self.sysfs.get_endpoints(dev) {
             endpoint.clear()?;

--- a/lib/src/source/pmt/sysfs.rs
+++ b/lib/src/source/pmt/sysfs.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 use crate::region::Region;
 use crate::source::{Capabilities, Capability};
 use std::collections::BTreeSet;
+#[cfg(feature = "control_commands")]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
This patch indicates that the `clear` command and the io::Write import should be gated by the `control_commands` feature.

The `control_commands` feature should handle the support to use Crash Log control commands and currently is the only feature in the Crash Log tool that uses writes to the linux sysfs.