### PR TITLE
lib: introduce `rearm` control command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,15 @@ $ iclg extract -s acpi,pmt:crashlog0
 ```
 
 - **List** all available Crash Log sources in the platform. Each source
-supports different capabilities like `extract`, `trigger`, or `enable/disable`.
+supports different capabilities like `extract`, `trigger`, `enable/disable`,
+or `rearm`.
 
 ```console
 $ iclg list
 Source         Description             Capabilities
--------------  ----------------------  ---------------------------------
+-------------  ----------------------  ---------------------------------------
 acpi           ACPI BERT               extract
-pmt:crashlog0  PMT endpoint crashlog0  extract, trigger, enable/disable
+pmt:crashlog0  PMT endpoint crashlog0  extract, trigger, enable/disable, rearm
 ```
 
 - **Trigger** a Crash Log collection on-demand. Like the `extract` command,
@@ -151,6 +152,16 @@ command is only supported on Linux.
 
 ```console
 $ iclg trigger
+```
+
+- **Rearm** a Crash Log trigger. A source can trigger a Crash Log collection
+only once per reset cycle; after a collection has been captured, the source
+must be reset and rearmed before it will trigger again. Like the `trigger`
+command, you can specify individual sources or rearm all sources by default.
+This command is only supported on Linux.
+
+```console
+$ iclg rearm
 ```
 
 - **Enable** or **Disable** the Crash Log collection in the platform.
@@ -189,18 +200,19 @@ $ iclg decode sample.crashlog
 $ iclg --help
 Extract and decode Intel Crash Log records.
 
-Usage: iclg [OPTIONS] [COMMAND]
+Usage: iclg [OPTIONS] <COMMAND>
 
 Commands:
-  enable   Enable the Crash Log collection in the platform
+  enable   Enable Crash Log collection in the platform
   extract  Extract the Crash Log records from the platform
   decode   Decode Crash Log records into JSON
-  disable  Disable the Crash Log collection in the platform
+  disable  Disable Crash Log collection in the platform
   info     List the Crash Log records stored in the input file
-  list     List the Crash Log sources that are present in the platform
+  list     List the Crash Log sources that are available in the platform
+  rearm    Rearm a Crash Log trigger in the platform
+  trigger  Trigger an on-demand Crash Log collection in the platform
   unpack   Unpack the Crash Log records stored in the input file
   triage   Triage the Crash Log records stored in the input files
-  trigger  Trigger an on-demand collection of Crash Log in the platform
   help     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/app/src/control.rs
+++ b/app/src/control.rs
@@ -3,6 +3,10 @@
 
 use intel_crashlog::prelude::*;
 
+pub fn rearm(sources: Vec<CrashLogSource>) -> Result<(), Error> {
+    control_command(sources, CrashLogSource::rearm)
+}
+
 pub fn trigger(sources: Vec<CrashLogSource>) -> Result<(), Error> {
     control_command(sources, CrashLogSource::trigger)
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -67,6 +67,11 @@ enum Command {
     },
     /// List the Crash Log sources that are available in the platform with their capabilities
     List,
+    /// Rearm a Crash Log trigger in the platform
+    Rearm {
+        #[arg(short, long, value_delimiter = ',')]
+        sources: Vec<CrashLogSource>,
+    },
     /// Trigger an on-demand Crash Log collection in the platform
     Trigger {
         #[arg(short, long, value_delimiter = ',')]
@@ -100,6 +105,7 @@ impl Command {
                 format,
             } => info::info(&cm, input_files, *format),
             Command::List => list::list(),
+            Command::Rearm { sources } => control::rearm(sources.clone())?,
             Command::Trigger { sources } => control::trigger(sources.clone())?,
             Command::Clear { sources } => control::clear(sources.clone())?,
             Command::Unpack { input_files } => {

--- a/lib/src/source.rs
+++ b/lib/src/source.rs
@@ -182,6 +182,15 @@ impl CrashLogSource {
         }
     }
 
+    /// Rearms a Crash Log trigger on this source
+    #[cfg(feature = "control_commands")]
+    pub fn rearm(&self) -> Result<(), Error> {
+        match self {
+            Self::PmtDevice(dev) => Pmt::default().rearm(dev),
+            _ => Err(Error::Unsupported),
+        }
+    }
+
     /// Clears the Crash Log storage on this source
     #[cfg(feature = "control_commands")]
     pub fn clear(&self) -> Result<(), Error> {

--- a/lib/src/source/capability.rs
+++ b/lib/src/source/capability.rs
@@ -17,6 +17,8 @@ pub enum Capability {
     EnableDisable,
     /// Clearing of the Crash Log storage
     Clear,
+    /// Rearming of the Crash Log trigger
+    Rearm,
 }
 
 impl fmt::Display for Capability {
@@ -26,6 +28,7 @@ impl fmt::Display for Capability {
             Self::Trigger => write!(f, "trigger"),
             Self::EnableDisable => write!(f, "enable/disable"),
             Self::Clear => write!(f, "clear"),
+            Self::Rearm => write!(f, "rearm"),
         }
     }
 }

--- a/lib/src/source/pmt.rs
+++ b/lib/src/source/pmt.rs
@@ -112,6 +112,19 @@ impl Pmt {
     }
 
     #[cfg(all(target_os = "linux", feature = "control_commands"))]
+    pub fn rearm(&self, dev: &PmtDeviceId) -> Result<(), Error> {
+        for endpoint in self.sysfs.get_endpoints(dev) {
+            endpoint.rearm()?;
+        }
+        Ok(())
+    }
+
+    #[cfg(all(not(target_os = "linux"), feature = "control_commands"))]
+    pub fn rearm(&self, _dev: &PmtDeviceId) -> Result<(), Error> {
+        Err(Error::Unsupported)
+    }
+
+    #[cfg(all(target_os = "linux", feature = "control_commands"))]
     pub fn trigger(&self, dev: &PmtDeviceId) -> Result<(), Error> {
         for endpoint in self.sysfs.get_endpoints(dev) {
             endpoint.trigger()?;

--- a/lib/src/source/pmt/sysfs.rs
+++ b/lib/src/source/pmt/sysfs.rs
@@ -249,6 +249,11 @@ impl PmtSysFsEndpoint {
     }
 
     #[cfg(feature = "control_commands")]
+    pub fn rearm(&self) -> Result<(), Error> {
+        self.write_command("rearm", b"1")
+    }
+
+    #[cfg(feature = "control_commands")]
     pub fn clear(&self) -> Result<(), Error> {
         self.write_command("clear", b"1")
     }
@@ -293,6 +298,10 @@ impl PmtSysFsEndpoint {
 
         if self.path.join("clear").exists() {
             capabilities.insert(Capability::Clear);
+        }
+
+        if self.path.join("rearm").exists() {
+            capabilities.insert(Capability::Rearm);
         }
 
         capabilities
@@ -436,6 +445,21 @@ mod tests {
     }
 
     #[test]
+    fn rearm() {
+        let root = tempfile::tempdir().unwrap();
+
+        let dev = PmtSysFsEndpoint::new(root.path()).unwrap();
+        assert!(matches!(dev.rearm(), Err(Error::IOError(_))));
+
+        let mut path = root.path().to_owned();
+        path.push("rearm");
+        std::fs::write(&path, b"0").unwrap();
+
+        dev.rearm().unwrap();
+        assert_eq!(&std::fs::read_to_string(&path).unwrap(), "1");
+    }
+
+    #[test]
     fn enable_disable() {
         let root = tempfile::tempdir().unwrap();
 
@@ -475,13 +499,18 @@ mod tests {
         trigger_path.push("trigger");
         std::fs::create_dir(&trigger_path).unwrap();
 
+        let mut rearm_path = dev_path.to_owned();
+        rearm_path.push("rearm");
+        std::fs::create_dir(&rearm_path).unwrap();
+
         let devices = sysfs.discover();
         let dev = sysfs.get_endpoints(&devices[0]);
         let dev_capabilities = dev[0].capabilities();
 
-        assert_eq!(dev_capabilities.len(), 2);
+        assert_eq!(dev_capabilities.len(), 3);
         assert!(dev_capabilities.contains(&Capability::Extract));
         assert!(dev_capabilities.contains(&Capability::Trigger));
+        assert!(dev_capabilities.contains(&Capability::Rearm));
     }
 
     #[test]


### PR DESCRIPTION
This patch includes support for the `rearm` Crash Log control command.

This command rearms the Crash Log trigger, it can be used for any Crash Log source that supports that capability, and can be called from the CLI:

    $ iclg rearm