### PR TITLE
feat: enable extract and control commands to access non-repeated Crash Log sources

### DIFF
--- a/app/src/control.rs
+++ b/app/src/control.rs
@@ -2,33 +2,66 @@
 // SPDX-License-Identifier: MIT
 
 use intel_crashlog::prelude::*;
+use intel_crashlog::source::Capability;
 
 pub fn rearm(sources: Vec<CrashLogSource>) -> Result<(), Error> {
-    control_command(sources, CrashLogSource::rearm)
+    run_control_command(sources, Capability::Rearm, CrashLogSource::rearm)
 }
 
 pub fn trigger(sources: Vec<CrashLogSource>) -> Result<(), Error> {
-    control_command(sources, CrashLogSource::trigger)
+    run_control_command(sources, Capability::Trigger, CrashLogSource::trigger)
 }
 
 pub fn clear(sources: Vec<CrashLogSource>) -> Result<(), Error> {
-    control_command(sources, CrashLogSource::clear)
+    run_control_command(sources, Capability::Clear, CrashLogSource::clear)
 }
 
 pub fn enable(sources: Vec<CrashLogSource>) -> Result<(), Error> {
-    control_command(sources, CrashLogSource::enable)
+    run_control_command(sources, Capability::EnableDisable, CrashLogSource::enable)
 }
 
 pub fn disable(sources: Vec<CrashLogSource>) -> Result<(), Error> {
-    control_command(sources, CrashLogSource::disable)
+    run_control_command(sources, Capability::EnableDisable, CrashLogSource::disable)
 }
 
-fn control_command<F>(sources: Vec<CrashLogSource>, control: F) -> Result<(), Error>
+fn run_control_command<F>(
+    sources: Vec<CrashLogSource>,
+    capability: Capability,
+    control: F,
+) -> Result<(), Error>
 where
     F: Fn(&CrashLogSource) -> Result<(), Error>,
 {
-    for source in sources {
-        control(&source)?;
+    let mut cmd_success = false;
+    let mut first_error = None;
+
+    let control_sources = if sources.is_empty() {
+        CrashLogSource::discover_distinct()
+            .into_iter()
+            .filter(|src| src.capabilities().contains(&capability))
+            .collect()
+    } else {
+        sources
+    };
+
+    if control_sources.is_empty() {
+        return Err(Error::NoCrashLogSourceFound);
+    }
+
+    for source in control_sources {
+        match control(&source) {
+            Ok(()) => cmd_success = true,
+            Err(err) => {
+                log::warn!("Error while running {capability} command on {source}: {err}");
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+    }
+
+    if !cmd_success {
+        return Err(first_error.unwrap_or(Error::InternalError));
     }
 
     Ok(())

--- a/app/src/list.rs
+++ b/app/src/list.rs
@@ -5,7 +5,7 @@ use super::table::{Row, Table};
 use intel_crashlog::source::CrashLogSource;
 
 pub fn list() {
-    let sources = CrashLogSource::discover();
+    let sources = CrashLogSource::discover_all_sources();
 
     if sources.is_empty() {
         println!("No available Crash Log sources found.");

--- a/lib/src/source.rs
+++ b/lib/src/source.rs
@@ -133,7 +133,28 @@ impl FromStr for CrashLogSource {
 
 impl CrashLogSource {
     /// Returns all the Crash Log sources that are available in the platform
+    #[deprecated(
+        since = "1.2.0",
+        note = "use `discover_all_sources` or `discover_distinct` instead"
+    )]
     pub fn discover() -> Vec<Self> {
+        Self::discover_sources()
+    }
+
+    /// Returns all the Crash Log sources that are available in the platform
+    pub fn discover_all_sources() -> Vec<Self> {
+        Self::discover_sources()
+    }
+
+    /// Returns all the Crash Log sources that are available in the platform without duplicates
+    pub fn discover_distinct() -> Vec<Self> {
+        Self::discover_sources()
+            .into_iter()
+            .filter(|src| !src.is_alias())
+            .collect()
+    }
+
+    fn discover_sources() -> Vec<Self> {
         let mut sources = Vec::new();
 
         if Acpi::default().is_available() {
@@ -153,6 +174,14 @@ impl CrashLogSource {
         sources.extend(pmt_devices);
 
         sources
+    }
+
+    /// Returns if the source is already an alias of another source in the system
+    fn is_alias(&self) -> bool {
+        match self {
+            Self::PmtDevice(dev) => dev.is_alias(),
+            _ => false,
+        }
     }
 
     /// Returns the Crash Log extracted from the platform using the current Crash Log source

--- a/lib/src/source/pmt.rs
+++ b/lib/src/source/pmt.rs
@@ -171,3 +171,10 @@ impl Pmt {
         }
     }
 }
+
+impl PmtDeviceId {
+    /// Returns if the source is already an alias of another source in the system
+    pub(super) fn is_alias(&self) -> bool {
+        matches!(self, PmtDeviceId::Bdf(..))
+    }
+}

--- a/lib/src/source/pmt/sysfs.rs
+++ b/lib/src/source/pmt/sysfs.rs
@@ -132,6 +132,7 @@ impl PmtSysFs {
     pub fn get_all_endpoints(&self) -> Vec<PmtSysFsEndpoint> {
         self.discover()
             .into_iter()
+            .filter(|dev| !dev.is_alias())
             .flat_map(|devid| self.get_endpoints(&devid))
             .collect()
     }


### PR DESCRIPTION
feat: enable `extract` and control commands to access non-repeated Crash Log sources

This patch enables `extract` command to collect all discovered Crash Log
sources when no -s parameter is provided and avoids to collect sources
that are mapped several times (e.g. BDF and sys class PMT sources):

    $ iclg extract

This change also impact the control commands;  the CLI will execute the
control command in all discovered Crash Log sources avoiding to execute
the command twice in the repeated sources:

    $ iclg trigger

This patch also includes `discover_distinct` method in the CrashLogSource
API, which is used to handle the logic to avoid returning these sources
that are mapped to 2 different endpoints

Signed-off-by: Rivas Paz, Jose L <jose.l.rivas.paz@intel.com>