### PR TITLE
lib: add support for clear command to the Event Log source

### DIFF
--- a/lib/src/source.rs
+++ b/lib/src/source.rs
@@ -196,6 +196,7 @@ impl CrashLogSource {
     pub fn clear(&self) -> Result<(), Error> {
         match self {
             Self::PmtDevice(dev) => Pmt::default().clear(dev),
+            Self::EventLog => EventLog::default().clear(),
             _ => Err(Error::Unsupported),
         }
     }
@@ -231,7 +232,7 @@ impl CrashLogSource {
     pub fn capabilities(&self) -> Capabilities {
         match self {
             Self::Acpi => Capabilities::from([Capability::Extract]),
-            Self::EventLog => Capabilities::from([Capability::Extract]),
+            Self::EventLog => Capabilities::from([Capability::Extract, Capability::Clear]),
             Self::PmtDevice(dev) => Pmt::default().capabilities(dev),
         }
     }

--- a/lib/src/source/event_log.rs
+++ b/lib/src/source/event_log.rs
@@ -40,6 +40,19 @@ impl EventLog {
 
         Err(Error::NoCrashLogFound)
     }
+
+    #[cfg(feature = "control_commands")]
+    pub fn clear(&self) -> Result<(), Error> {
+        #[cfg(all(target_family = "windows", feature = "std"))]
+        {
+            match win::clear_whea_errors() {
+                Ok(_) => return Ok(()),
+                Err(err) => log::error!("Cannot clear event log: {err}"),
+            }
+        }
+
+        Err(Error::Unsupported)
+    }
 }
 
 impl CrashLog {

--- a/lib/src/source/event_log/win.rs
+++ b/lib/src/source/event_log/win.rs
@@ -311,3 +311,13 @@ pub(super) fn extract_crashlogs(path: Option<&Path>) -> Result<Vec<CrashLog>> {
     crashlogs.append(&mut system_crashlogs);
     Ok(crashlogs)
 }
+
+#[cfg(feature = "control_commands")]
+pub(super) fn clear_whea_errors() -> Result<()> {
+    // Clear the dedicated WHEA/Errors channel
+    unsafe {
+        EvtClearLog(None, w!("Microsoft-Windows-Kernel-WHEA/Errors"), None, 0)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The clear command can now be used to clear the WHEA error records from the Windows Event Log:

    $ iclg clear -s evt